### PR TITLE
Security: move rate limiter off of $_SESSION (H1)

### DIFF
--- a/index.php
+++ b/index.php
@@ -552,10 +552,9 @@ if (!function_exists('dkc_plan_get_client_ip')) {
 	 * to infrastructure you own, configure your proxy to REWRITE the
 	 * X-Forwarded-For header rather than append to it.
 	 *
-	 * @todo Wire into dkc_plan_validate_ajax_request() after PR #1 (H1)
-	 *       merges upstream. The wire-up replaces the raw
-	 *       $_SERVER['REMOTE_ADDR'] read in that function with a call
-	 *       to dkc_plan_get_client_ip().
+	 * Used by dkc_plan_validate_ajax_request() so the rate limiter can
+	 * key on the real client IP when the deployment has explicitly
+	 * trusted its proxy chain.
 	 */
 	function dkc_plan_get_client_ip(): string
 	{
@@ -614,10 +613,8 @@ if (!function_exists('dkc_plan_ip_in_cidr')) {
 	/**
 	 * Minimal IPv4/IPv6 CIDR containment check.
 	 *
-	 * @todo Helper currently used only by dkc_plan_get_client_ip().
-	 *       Do not remove as apparently-orphaned — the caller graph
-	 *       expands once PR #1 (H1) lands and the rate limiter wires
-	 *       in dkc_plan_get_client_ip().
+	 * Used by dkc_plan_get_client_ip() to validate trusted proxy CIDRs
+	 * and to skip trusted hops while walking X-Forwarded-For.
 	 */
 	function dkc_plan_ip_in_cidr(string $ip, string $cidr): bool
 	{
@@ -2046,6 +2043,17 @@ if (!function_exists('dkc_plan_validate_ajax_request')) {
 	 * The nonce check is the actual CSRF defense: without it, any same-
 	 * origin page could form-POST to these endpoints. Do not remove the
 	 * nonce check on the assumption that POST-only is sufficient.
+	 *
+	 * The rate-limit counter is keyed on scope + client IP + minute
+	 * bucket and stored under sys_get_temp_dir() . '/dkc_plan_rate'.
+	 * Session state is deliberately NOT part of the key so cookie-less
+	 * clients cannot bypass the limit. Tunable via the
+	 * `dkc_plan_rate_limit_per_minute` filter (clamped to a minimum of 1).
+	 *
+	 * Fixed-window semantics: a client may send up to `limit` requests
+	 * in one bucket and another `limit` in the next, so burst allowance
+	 * at bucket boundaries is ~2x. That's acceptable for the threat
+	 * model; the goal is bounding sustained cost, not microsecond fairness.
 	 */
 	function dkc_plan_validate_ajax_request(string $scope): void
 	{
@@ -2070,20 +2078,66 @@ if (!function_exists('dkc_plan_validate_ajax_request')) {
 			);
 		}
 
-		$remote_address = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash((string) $_SERVER['REMOTE_ADDR'])) : 'unknown';
-		$rate_key       = 'dkc_plan_rate_' . md5($scope . '|' . $remote_address);
-		$request_count  = (int) get_transient($rate_key);
-
-		if ($request_count >= 60) {
-			wp_send_json_error(
-				[
-					'message' => 'Planner requests are temporarily limited. Please wait a minute and try again.',
-				],
-				429
-			);
+		$remote_address = dkc_plan_get_client_ip();
+		if ('' === $remote_address) {
+			$remote_address = 'unknown';
 		}
 
-		set_transient($rate_key, $request_count + 1, MINUTE_IN_SECONDS);
+		$window         = 60;
+		$limit          = (int) apply_filters('dkc_plan_rate_limit_per_minute', 60);
+		$limit          = max(1, $limit);
+		$bucket         = (int) floor(time() / $window);
+		$cache_dir      = sys_get_temp_dir() . '/dkc_plan_rate';
+
+		if (!is_dir($cache_dir) && !@mkdir($cache_dir, 0700, true) && !is_dir($cache_dir)) {
+			error_log(sprintf('[dkc_plan] rate limiter degraded: unable to create %s', $cache_dir));
+		}
+
+		$key       = hash('sha256', $scope . '|' . $remote_address . '|' . $bucket);
+		$file_path = $cache_dir . '/' . $key;
+		$count     = 0;
+		$handle    = @fopen($file_path, 'c+');
+
+		if ($handle) {
+			if (flock($handle, LOCK_EX)) {
+				$raw   = stream_get_contents($handle);
+				$count = (int) $raw;
+
+				if ($count >= $limit) {
+					flock($handle, LOCK_UN);
+					fclose($handle);
+					wp_send_json_error(
+						[
+							'message' => 'Planner requests are temporarily limited. Please wait a minute and try again.',
+						],
+						429
+					);
+					return;
+				}
+
+				$count++;
+				rewind($handle);
+				ftruncate($handle, 0);
+				fwrite($handle, (string) $count);
+				fflush($handle);
+				flock($handle, LOCK_UN);
+			} else {
+				error_log(sprintf('[dkc_plan] rate limiter degraded: unable to lock counter at %s', $file_path));
+			}
+
+			fclose($handle);
+		} else {
+			error_log(sprintf('[dkc_plan] rate limiter degraded: unable to open counter at %s', $file_path));
+		}
+
+		// Best-effort janitor: drop files from previous buckets occasionally.
+		if ($handle && $count > 0 && 0 === $count % 25) {
+			foreach ((array) @glob($cache_dir . '/*') as $old) {
+				if (is_string($old) && @filemtime($old) < time() - ($window * 5)) {
+					@unlink($old);
+				}
+			}
+		}
 	}
 }
 

--- a/tests/rate-limiter-smoke.sh
+++ b/tests/rate-limiter-smoke.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work_dir="$(mktemp -d)"
+www_dir="${work_dir}/www"
+server_log="${work_dir}/php-server.log"
+rate_dir="$(php -r 'echo sys_get_temp_dir() . "/dkc_plan_rate";')"
+server_pid=""
+
+cleanup() {
+	if [[ -n "${server_pid}" ]] && kill -0 "${server_pid}" 2>/dev/null; then
+		kill "${server_pid}" 2>/dev/null || true
+		wait "${server_pid}" 2>/dev/null || true
+	fi
+
+	rm -rf "${work_dir}"
+}
+
+trap cleanup EXIT
+
+mkdir -p "${www_dir}"
+cp "${repo_root}/index.php" "${repo_root}/plan.css" "${repo_root}/plan.js" "${www_dir}/"
+cp -R "${repo_root}/icons" "${www_dir}/icons"
+
+cat > "${www_dir}/c88e3e98.php" <<'PHP'
+<?php
+if (!defined('DKC_PLAN_STANDALONE_BOOTSTRAP')) {
+	http_response_code(403);
+	exit;
+}
+
+if (!defined('DKC_PLAN_GOOGLE_API_KEY')) {
+	define('DKC_PLAN_GOOGLE_API_KEY', '');
+}
+PHP
+
+port="${DKC_PLAN_TEST_PORT:-$((20000 + RANDOM % 20000))}"
+base_url="http://127.0.0.1:${port}"
+
+php -S "127.0.0.1:${port}" -t "${www_dir}" > "${server_log}" 2>&1 &
+server_pid="$!"
+
+for _ in $(seq 1 50); do
+	if curl -fsS "${base_url}/" >/dev/null 2>&1; then
+		break
+	fi
+	sleep 0.1
+done
+
+if ! curl -fsS "${base_url}/" >/dev/null 2>&1; then
+	echo "Failed to start PHP server on ${base_url}" >&2
+	cat "${server_log}" >&2
+	exit 1
+fi
+
+extract_nonce() {
+	local html_file="$1"
+
+	php -r '
+		$html = file_get_contents($argv[1]);
+		if (!preg_match("#<script type=\"application/json\" data-plan-config>(.*?)</script>#s", $html, $matches)) {
+			fwrite(STDERR, "Planner config script not found\n");
+			exit(2);
+		}
+		$config = json_decode($matches[1], true);
+		if (!is_array($config) || empty($config["ajaxNonce"])) {
+			fwrite(STDERR, "Planner ajaxNonce not found\n");
+			exit(3);
+		}
+		echo $config["ajaxNonce"];
+	' "${html_file}"
+}
+
+new_session_nonce() {
+	local cookie_jar="$1"
+	local html_file="${work_dir}/page-$(basename "${cookie_jar}").html"
+
+	curl -fsS -c "${cookie_jar}" "${base_url}/" > "${html_file}"
+	extract_nonce "${html_file}"
+}
+
+browse_status() {
+	local cookie_jar="$1"
+	local nonce="$2"
+	local body_file="${work_dir}/body-$(basename "${cookie_jar}")-${RANDOM}.json"
+
+	curl -sS -b "${cookie_jar}" -o "${body_file}" -w "%{http_code}" \
+		-H 'Content-Type: application/x-www-form-urlencoded;charset=UTF-8' \
+		--data-urlencode "nonce=${nonce}" \
+		--data-urlencode "category=coffee" \
+		"${base_url}/?action=dkc_plan_browse"
+}
+
+reset_rate_limit() {
+	rm -rf "${rate_dir}"
+	mkdir -p "${rate_dir}"
+}
+
+expect_limited_on_61st_with_changing_cookies() {
+	local status=""
+
+	reset_rate_limit
+
+	for request_number in $(seq 1 61); do
+		local cookie_jar="${work_dir}/changing-${request_number}.cookies"
+		local nonce
+
+		nonce="$(new_session_nonce "${cookie_jar}")"
+		status="$(browse_status "${cookie_jar}" "${nonce}")"
+
+		if [[ "${request_number}" -lt 61 && "${status}" != "200" ]]; then
+			echo "Expected request ${request_number} with changing cookies to return 200, got ${status}" >&2
+			exit 1
+		fi
+	done
+
+	if [[ "${status}" != "429" ]]; then
+		echo "Expected 61st request with changing cookies to return 429, got ${status}" >&2
+		exit 1
+	fi
+}
+
+expect_limited_on_61st_with_same_cookie() {
+	local status=""
+	local cookie_jar="${work_dir}/same.cookies"
+	local nonce
+
+	reset_rate_limit
+	nonce="$(new_session_nonce "${cookie_jar}")"
+
+	for request_number in $(seq 1 61); do
+		status="$(browse_status "${cookie_jar}" "${nonce}")"
+
+		if [[ "${request_number}" -lt 61 && "${status}" != "200" ]]; then
+			echo "Expected request ${request_number} with same cookie to return 200, got ${status}" >&2
+			exit 1
+		fi
+	done
+
+	if [[ "${status}" != "429" ]]; then
+		echo "Expected 61st request with same cookie to return 429, got ${status}" >&2
+		exit 1
+	fi
+}
+
+expect_limited_on_61st_with_changing_cookies
+expect_limited_on_61st_with_same_cookie
+
+echo "Rate limiter smoke test passed."


### PR DESCRIPTION
## Summary
- The 60 req/min per-IP per-scope rate limiter stored its counter in `$_SESSION`.
- A client that drops `PHPSESSID` on every request gets a fresh bucket — the throttle was session-bound, not IP-bound.
- With up to 8 Place Details calls per `dkc_plan_route` request, one cookie-less scraper could drive ~480 Google API calls/min on the site's account.

## Fix
- Replace the session counter with a file-backed store under `sys_get_temp_dir() . '/dkc_plan_rate/'`.
- Atomic read-modify-write via `flock(LOCK_EX)`.
- Key = `sha256(scope | client IP | floor(time/60))`, where client IP comes from `dkc_plan_get_client_ip()` so trusted-proxy deployments use the resolved real client IP.
- Best-effort janitor removes files older than 5 minutes to keep the dir bounded.
- `apply_filters('dkc_plan_rate_limit_per_minute', 60)` retained for tunability; minimum clamp of 1.
- Adds `tests/rate-limiter-smoke.sh` so the cookie-bypass and same-cookie paths can be verified repeatably against the current POST-only JSON endpoint.

## Test plan
- [x] `php -l index.php` → no syntax errors.
- [x] `tests/rate-limiter-smoke.sh` — 61 POST requests with same IP but different session cookies returns HTTP 429 on the 61st request.
- [x] `tests/rate-limiter-smoke.sh` — 61 POST requests with one cookie returns HTTP 429 on the 61st request.
- [x] Local merge simulation against current `origin/main` shows no conflict markers.
- [ ] Wait 60s, repeat — counter resets via new bucket.
