### PR TITLE
Security: split embed and Places API keys (H3)

### DIFF
--- a/c88e3e98.example.php
+++ b/c88e3e98.example.php
@@ -27,6 +27,29 @@ if (!defined('DKC_PLAN_STANDALONE_BOOTSTRAP')) {
 	exit;
 }
 
+/*
+ * SECURITY: two separate keys are strongly recommended.
+ *
+ * The Embed key is visible in the browser (it's the src= of the Maps
+ * iframe). The Places key is only used server-side and should never
+ * reach the browser. If you supply only DKC_PLAN_GOOGLE_API_KEY the
+ * planner will use it for both, and you MUST restrict that single key
+ * in Google Cloud to Maps Embed API + your site's referring domain.
+ *
+ * With two keys you can scope the Embed key to Maps Embed API only and
+ * the Places key to Places API (New) + Geocoding API, so a leaked
+ * browser-side key can't drive Places calls.
+ */
+if (!defined('DKC_PLAN_GOOGLE_EMBED_API_KEY')) {
+	define('DKC_PLAN_GOOGLE_EMBED_API_KEY', '');
+}
+
+if (!defined('DKC_PLAN_GOOGLE_PLACES_API_KEY')) {
+	define('DKC_PLAN_GOOGLE_PLACES_API_KEY', '');
+}
+
+// Legacy single-key fallback. If the two above are empty, this is used
+// for both server-side Places and browser-side Embed.
 if (!defined('DKC_PLAN_GOOGLE_API_KEY')) {
 	define('DKC_PLAN_GOOGLE_API_KEY', '');
 }

--- a/index.php
+++ b/index.php
@@ -508,19 +508,31 @@ if (!function_exists('dkc_plan_get_google_api_key')) {
 			$default_key = (string) DKC_PLAN_GOOGLE_API_KEY;
 		}
 
-		$default_key = (string) apply_filters('dkc_plan_google_embed_api_key', $default_key);
-
 		return (string) apply_filters('dkc_plan_google_api_key', $default_key);
 	}
 }
 
 if (!function_exists('dkc_plan_get_google_embed_api_key')) {
 	/**
-	 * Backwards-compatible embed key accessor.
+	 * Return the API key used for the browser-facing Maps Embed iframe.
+	 *
+	 * Prefers DKC_PLAN_GOOGLE_EMBED_API_KEY; falls back to the legacy
+	 * DKC_PLAN_GOOGLE_API_KEY when the dedicated constant is unset or
+	 * empty. The `dkc_plan_google_embed_api_key` filter is applied last.
 	 */
 	function dkc_plan_get_google_embed_api_key(): string
 	{
-		return dkc_plan_get_google_api_key();
+		$key = '';
+
+		if (defined('DKC_PLAN_GOOGLE_EMBED_API_KEY')) {
+			$key = (string) DKC_PLAN_GOOGLE_EMBED_API_KEY;
+		}
+
+		if ('' === $key) {
+			$key = dkc_plan_get_google_api_key();
+		}
+
+		return (string) apply_filters('dkc_plan_google_embed_api_key', $key);
 	}
 }
 
@@ -530,7 +542,17 @@ if (!function_exists('dkc_plan_get_google_places_api_key')) {
 	 */
 	function dkc_plan_get_google_places_api_key(): string
 	{
-		return (string) apply_filters('dkc_plan_google_places_api_key', dkc_plan_get_google_api_key());
+		$key = '';
+
+		if (defined('DKC_PLAN_GOOGLE_PLACES_API_KEY')) {
+			$key = (string) DKC_PLAN_GOOGLE_PLACES_API_KEY;
+		}
+
+		if ('' === $key) {
+			$key = dkc_plan_get_google_api_key();
+		}
+
+		return (string) apply_filters('dkc_plan_google_places_api_key', $key);
 	}
 }
 


### PR DESCRIPTION
## Summary
- One Google key was used for both the browser-visible Maps Embed iframe and the server-only Places + Geocoding calls.
- If that key isn't correctly restricted in Google Cloud, the browser copy is usable for paid Places API calls by anyone.

## Fix
- Add `DKC_PLAN_GOOGLE_EMBED_API_KEY` and `DKC_PLAN_GOOGLE_PLACES_API_KEY` constants; either falls back to the legacy single `DKC_PLAN_GOOGLE_API_KEY` if not set.
- Update `c88e3e98.example.php` to document the split and the Google Cloud restriction each key needs.
- Existing deployments work unchanged; new deployments get a safer default path.

## Test plan
- [x] `php -l` on both files.
- [ ] With only `DKC_PLAN_GOOGLE_API_KEY` defined, both getters return it.
- [ ] With split keys defined, each getter returns its own.
