### PR TITLE
Security: neutralize </script> in JSON config blob (M4)

### DIFF
--- a/index.php
+++ b/index.php
@@ -74,7 +74,7 @@ if (!function_exists('wp_json_encode')) {
 	{
 		$encoded = json_encode(
 			$value,
-			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+			JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG
 		);
 
 		return false === $encoded ? 'null' : $encoded;


### PR DESCRIPTION
## Summary
- The rendered page embeds the planner config in a `<script type="application/json" data-plan-config>` block.
- If any user-influenced string in that payload contains the literal sequence `</script>`, the HTML parser ends the script element early and subsequent bytes are treated as HTML — a stored-XSS primitive on top of whatever field got polluted.

## Fix
- In the `wp_json_encode` shim, drop `JSON_UNESCAPED_SLASHES` and add `JSON_HEX_TAG`.
- Final flag set: `JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG`.
- `JSON_HEX_TAG` encodes `<` and `>` as `\u003C` / `\u003E`, so `</script>` can never appear literally in the emitted JSON.
- Dropping `JSON_UNESCAPED_SLASHES` also converts `/` to `\/`, so `</script>` becomes `<\/script>` even before the HEX_TAG pass — belt and suspenders.

## Test plan
- [x] `php -l index.php` → no syntax errors.
- [x] Inline encode check:
  ```
  php -r 'echo json_encode(["x" => "</script><img onerror=alert(1)>"],
    JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG), "\n";'
  ```
  Output: `{"x":"\u003C\/script\u003E\u003Cimg onerror=alert(1)\u003E"}` — no literal `<` or `>`.

Part of a series addressing the findings documented at `.claude/SECURITY_REVIEW.md` locally.
