### PR TITLE
Security: harden session cookie (L1)

### DIFF
--- a/index.php
+++ b/index.php
@@ -46,6 +46,14 @@ if (!defined('DAY_IN_SECONDS')) {
  * use.
  */
 if (PHP_SESSION_NONE === session_status()) {
+	session_set_cookie_params([
+		'lifetime' => 0,
+		'path'     => '/',
+		'domain'   => '',
+		'secure'   => !empty($_SERVER['HTTPS']) && 'off' !== strtolower((string) $_SERVER['HTTPS']),
+		'httponly' => true,
+		'samesite' => 'Lax',
+	]);
 	session_start();
 }
 


### PR DESCRIPTION
## Summary
- The standalone planner calls `session_start()` with PHP's default cookie parameters: no explicit `HttpOnly`, no `SameSite`, `Secure` only if `session.cookie_secure` happens to be on in `php.ini`.
- On a deployment that forgets to configure those ini settings, the `PHPSESSID` cookie is readable from JavaScript, attached to cross-site subresource loads, and can travel over plaintext HTTP.

## Fix
Configure the session cookie explicitly inside the existing `if (PHP_SESSION_NONE === session_status())` block, immediately before `session_start()`:

- `httponly => true` — JavaScript cannot read `PHPSESSID`.
- `samesite => 'Lax'` — browsers withhold the cookie on cross-site subresource loads (`<img src>`, `<iframe src>`, `fetch` from third-party pages). Top-level navigations (clicking a link, pasting a URL) still carry it, so user-initiated flows are unaffected.
- `secure` conditional on `$_SERVER['HTTPS']` — HTTPS deployments never leak the cookie over plaintext, but local `http://` dev still works.
- `lifetime => 0`, `path => '/'`, `domain => ''` — session-lifetime, site-wide, default host (unchanged from PHP defaults, made explicit).

The call must happen *before* `session_start()` — `session_set_cookie_params` only affects the cookie emitted by the session that is subsequently started.

## Relationship to M1
PR #4 (`fix/m1-csrf-origin-check`, M1) also sets these same parameters as part of its CSRF defense-in-depth. Whichever lands first, the other is trivially resolvable:
- If M1 merges first, this PR becomes a no-op and can be closed.
- If L1 merges first, M1 will rebase and drop the duplicate block.

Neither is merged at dispatch time, so both are being authored in parallel.

## Test plan
- [x] `php -l index.php` — no syntax errors.
- [ ] Load the page on an HTTP dev server, inspect the `Set-Cookie: PHPSESSID=...` header: expect `HttpOnly; SameSite=Lax`, no `Secure`.
- [ ] Load over HTTPS: expect `HttpOnly; Secure; SameSite=Lax`.
- [ ] Verify top-level navigation into the planner still sees the session (SameSite=Lax allows this).

Part of a series addressing the findings documented at `.claude/SECURITY_REVIEW.md` locally.
