### PR TITLE
Security: https:// allowlist for externally sourced URLs (M3)

### DIFF
--- a/index.php
+++ b/index.php
@@ -161,6 +161,22 @@ if (!function_exists('esc_url')) {
 	}
 }
 
+if (!function_exists('dkc_plan_safe_https_url')) {
+	/**
+	 * Return the input only if it is a plain https:// URL.
+	 *
+	 * Used for externally sourced URL fields (currently Google's
+	 * googleMapsUri). Defends against an upstream ever returning a
+	 * non-https scheme — e.g. javascript: — landing in an href.
+	 */
+	function dkc_plan_safe_https_url(string $url): string
+	{
+		$url = trim($url);
+
+		return 1 === preg_match('#\Ahttps://[^\s<>"\']+\z#i', $url) ? $url : '';
+	}
+}
+
 if (!function_exists('checked')) {
 	/**
 	 * Echo a checked attribute when two values match.
@@ -813,7 +829,7 @@ if (!function_exists('dkc_plan_parse_google_place')) {
 		$place_id  = dkc_plan_sanitize_place_id((string) ($place['id'] ?? ''));
 		$label     = trim((string) ($place['displayName']['text'] ?? ''));
 		$address   = trim((string) ($place['formattedAddress'] ?? ''));
-		$maps_uri  = trim((string) ($place['googleMapsUri'] ?? ''));
+		$maps_uri  = dkc_plan_safe_https_url((string) ($place['googleMapsUri'] ?? ''));
 		$latitude  = isset($place['location']['latitude']) ? (float) $place['location']['latitude'] : null;
 		$longitude = isset($place['location']['longitude']) ? (float) $place['location']['longitude'] : null;
 

--- a/plan.js
+++ b/plan.js
@@ -208,6 +208,9 @@
 
   const escapeAttr = (value) => escapeHtml(value);
 
+  const safeHttpsUrl = (value) =>
+    /^https:\/\/[^\s<>"']+$/i.test(String(value ?? '')) ? String(value) : '';
+
   const getCurrentPlannerState = () => ({
     category: state.browse.activeCategoryKey,
     selectedWaypointIds: [...state.trip.selectedWaypointIds],
@@ -680,9 +683,9 @@
                 </div>
                 <div class="dkc-plan__result-tools">
                   ${
-                    result.maps_uri
+                    safeHttpsUrl(result.maps_uri)
                       ? `<a class="dkc-plan__result-link" href="${escapeAttr(
-                          result.maps_uri
+                          safeHttpsUrl(result.maps_uri)
                         )}" target="_blank" rel="noopener noreferrer">View in Google Maps</a>`
                       : ''
                   }


### PR DESCRIPTION
## Summary
- `result.maps_uri` is sourced from Google's `googleMapsUri` and rendered directly into an `<a href>`.
- If the upstream ever returns a non-`https:` scheme (e.g. `javascript:`), it lands in the href unchecked.

## Fix
- Add `dkc_plan_safe_https_url()`: returns the input only if it matches `\Ahttps://[^\s<>"']+\z` (case-insensitive).
- Filter `googleMapsUri` through the helper in `dkc_plan_parse_google_place` so every downstream consumer — server render and JSON payload to `plan.js` — only ever sees a safe URL.
- Mirror the helper in `plan.js` as `safeHttpsUrl()` and apply it wherever `result.maps_uri` is rendered (belt-and-suspenders for any future direct-from-JS rendering).

## Test plan
- [x] `php -l index.php` → no syntax errors.
- [x] Inline regex check: `https://example.com/x` accepted; `javascript:alert(1)`, `http://example.com`, and `https://a.com">b` all rejected.
- [ ] Browse results still render "View in Google Maps" links for normal Google responses.

Part of a series addressing the findings documented at .claude/SECURITY_REVIEW.md locally.
