### PR TITLE
Security: baseline security headers on page render (M5, subsumes L2)

### DIFF
--- a/index.php
+++ b/index.php
@@ -1875,6 +1875,26 @@ if ('dkc_plan_route' === $planner_endpoint_action) {
 	dkc_plan_handle_route_request();
 }
 
+if (!headers_sent()) {
+	header('X-Content-Type-Options: nosniff');
+	header('X-Frame-Options: SAMEORIGIN');
+	header('Referrer-Policy: strict-origin-when-cross-origin');
+	header(
+		"Content-Security-Policy: default-src 'self'; "
+		. "img-src 'self' data: https:; "
+		. "frame-src https://www.google.com; "
+		. "script-src 'self'; "
+		. "style-src 'self' 'unsafe-inline'; "
+		. "connect-src 'self'; "
+		. "base-uri 'none'; "
+		. "form-action 'self'"
+	);
+
+	if (defined('DKC_PLAN_ENABLE_HSTS') && DKC_PLAN_ENABLE_HSTS) {
+		header('Strict-Transport-Security: max-age=31536000; includeSubDomains');
+	}
+}
+
 $planner_section_id         = 'dkc-plan-your-day';
 $planner_title_id           = $planner_section_id . '-title';
 $planner_category_help_id   = $planner_section_id . '-category-help';


### PR DESCRIPTION
## Summary
- Adds a small block of baseline HTTP response headers on the full-page planner render (after endpoint dispatch, before HTML output).
- Headers emitted: `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, and a scoped `Content-Security-Policy`.
- **Subsumes L2** (iframe `referrerpolicy` leak): the `Referrer-Policy: strict-origin-when-cross-origin` header now governs the Google Maps Embed iframe (and every other outbound navigation from the page), so the per-iframe `referrerpolicy` attribute is no longer load-bearing.

## CSP breakdown
- `default-src 'self'` — deny by default.
- `img-src 'self' data: https:` — planner icons + Google place photos.
- `frame-src https://www.google.com` — the Maps Embed iframe.
- `script-src 'self'` — only `plan.js` from our own origin.
- `style-src 'self' 'unsafe-inline'` — `plan.css` plus inline-style usage already present in the markup.
- `connect-src 'self'` — the planner's own JSON endpoints.
- `base-uri 'none'`, `form-action 'self'` — block `<base>` and form hijacking.

## HSTS
- Gated behind the opt-in `DKC_PLAN_ENABLE_HSTS` constant (default off) so HTTP-only deployments are not accidentally locked out.

## Test plan
- [x] `php -l index.php` clean.
- [x] `curl -sI` against the local `php -S` render shows all four required headers, and HSTS is absent by default.
- [ ] With `define('DKC_PLAN_ENABLE_HSTS', true)` the `Strict-Transport-Security` header is emitted.

Part of a series addressing findings at `.claude/SECURITY_REVIEW.md` locally.
