### PR TITLE
Security: disable display_errors at bootstrap (L5)

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,6 +11,16 @@ declare(strict_types=1);
  */
 
 /*
+ * Never leak PHP errors to HTTP responses. Deployment-level
+ * php.ini may override this, but the default for this planner
+ * is to log only — any runtime notice or warning would otherwise
+ * corrupt JSON endpoint responses and expose local paths.
+ */
+@ini_set('display_errors', '0');
+@ini_set('display_startup_errors', '0');
+error_reporting(E_ALL);
+
+/*
  * Load the standalone Google Maps API key from a separate local PHP config.
  *
  * A .php config file is safer than .inc on this Apache/PHP stack because it is


### PR DESCRIPTION
## Summary
- Any runtime notice or warning currently lands in the HTTP response body.
- For JSON endpoints that corrupts the payload; for the HTML render it can leak local filesystem paths, function internals, and DB/API call context.

## Fix
- At the very top of `index.php`, right after the file's leading doc comment, force `display_errors` and `display_startup_errors` off.
- `@` suppression on `ini_set` so hosts that restrict the directive via `disable_functions` / `ini_set` restrictions don't emit a warning *before* `display_errors` takes effect.
- `error_reporting(E_ALL)` retained so `error_log` still captures everything for operators — only browser-visible output is suppressed.
- Deployment-level `php.ini` can still override this; this is the safe default.

## Test plan
- [x] `php -l index.php` → no syntax errors.
- [ ] With `display_errors=On` in php.ini, a forced `trigger_error('x', E_USER_WARNING)` inside `index.php` does not appear in the HTTP response.
- [ ] Same trigger_error is captured via `error_log` / the web server error log.

Part of a series addressing the findings documented at `.claude/SECURITY_REVIEW.md` locally.
