### PR TITLE
Security: require POST on planner JSON endpoints (M2)

### DIFF
--- a/index.php
+++ b/index.php
@@ -1774,7 +1774,16 @@ if (!function_exists('dkc_plan_validate_ajax_request')) {
 	 */
 	function dkc_plan_validate_ajax_request(string $scope): void
 	{
-		$nonce = isset($_GET['nonce']) ? sanitize_text_field(wp_unslash((string) $_GET['nonce'])) : '';
+		if ('POST' !== (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+			wp_send_json_error(
+				[
+					'message' => 'Planner endpoints require POST.',
+				],
+				405
+			);
+		}
+
+		$nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash((string) $_POST['nonce'])) : '';
 
 		if (!wp_verify_nonce($nonce, 'dkc_plan_ajax')) {
 			wp_send_json_error(
@@ -1812,7 +1821,7 @@ if (!function_exists('dkc_plan_handle_browse_request')) {
 	{
 		dkc_plan_validate_ajax_request('browse');
 
-		$request_args = dkc_plan_get_request_state_args($_GET);
+		$request_args = dkc_plan_get_request_state_args($_POST);
 		$planner_state = dkc_plan_build_runtime_state(
 			$request_args,
 			[
@@ -1840,7 +1849,7 @@ if (!function_exists('dkc_plan_handle_route_request')) {
 	{
 		dkc_plan_validate_ajax_request('route');
 
-		$request_args = dkc_plan_get_request_state_args($_GET);
+		$request_args = dkc_plan_get_request_state_args($_POST);
 		$planner_state = dkc_plan_build_runtime_state(
 			$request_args,
 			[
@@ -1867,12 +1876,17 @@ if (!function_exists('dkc_plan_handle_route_request')) {
  */
 $planner_endpoint_action = isset($_GET['action']) ? sanitize_key(wp_unslash((string) $_GET['action'])) : '';
 
-if ('dkc_plan_browse' === $planner_endpoint_action) {
-	dkc_plan_handle_browse_request();
-}
-
-if ('dkc_plan_route' === $planner_endpoint_action) {
-	dkc_plan_handle_route_request();
+if ('dkc_plan_browse' === $planner_endpoint_action || 'dkc_plan_route' === $planner_endpoint_action) {
+	// These are exclusively POST endpoints now. A stray GET on the
+	// action= query parameter during a full-page navigation should just
+	// render the page (ignore the action), not error out.
+	if ('POST' === (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+		if ('dkc_plan_browse' === $planner_endpoint_action) {
+			dkc_plan_handle_browse_request();
+		} else {
+			dkc_plan_handle_route_request();
+		}
+	}
 }
 
 $planner_section_id         = 'dkc-plan-your-day';

--- a/plan.js
+++ b/plan.js
@@ -243,11 +243,17 @@
   const buildAjaxUrl = (action) => {
     const nextUrl = new URL(config.ajaxUrl || window.location.pathname, window.location.origin);
     nextUrl.searchParams.set('action', action);
-    if (config.ajaxNonce) {
-      nextUrl.searchParams.set('nonce', config.ajaxNonce);
-    }
-    appendStateToSearchParams(nextUrl.searchParams, getCurrentPlannerState());
     return nextUrl;
+  };
+
+  const buildAjaxBody = (action) => {
+    const body = new URLSearchParams();
+    appendStateToSearchParams(body, getCurrentPlannerState());
+    body.set('action', action);
+    if (config.ajaxNonce) {
+      body.set('nonce', config.ajaxNonce);
+    }
+    return body;
   };
 
   const syncUrl = () => {
@@ -1018,12 +1024,15 @@
     renderAll();
   };
 
-  const fetchJson = async (scope, url, controller) => {
+  const fetchJson = async (scope, url, body, controller) => {
     const response = await window.fetch(url.toString(), {
+      method: 'POST',
       credentials: 'same-origin',
       headers: {
         Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       },
+      body,
       signal: controller.signal,
       cache: 'no-store',
     });
@@ -1121,9 +1130,11 @@
     }
 
     try {
+      const browseAction = config.endpoints?.browseAction || 'dkc_plan_browse';
       const responseData = await fetchJson(
         'browse',
-        buildAjaxUrl(config.endpoints?.browseAction || 'dkc_plan_browse'),
+        buildAjaxUrl(browseAction),
+        buildAjaxBody(browseAction),
         browseRequestController
       );
 
@@ -1175,9 +1186,11 @@
     });
 
     try {
+      const routeAction = config.endpoints?.routeAction || 'dkc_plan_route';
       const responseData = await fetchJson(
         'route',
-        buildAjaxUrl(config.endpoints?.routeAction || 'dkc_plan_route'),
+        buildAjaxUrl(routeAction),
+        buildAjaxBody(routeAction),
         routeRequestController
       );
 


### PR DESCRIPTION
## Summary
- The `dkc_plan_browse` and `dkc_plan_route` JSON endpoints accepted GET, so a third-party page could link or `<img>`-src to them and drive paid Google API calls on any visitor with a leaked nonce.
- GET also lets shared caches store responses and leaks the nonce into `Referer` headers sent to Google.

## Fix
- `dkc_plan_validate_ajax_request` now returns 405 on non-POST (checked before the nonce check) and reads the nonce from `$_POST`.
- Endpoint dispatch only invokes handlers when `REQUEST_METHOD === 'POST'`. A GET with `?action=dkc_plan_*` falls through to the full-page render rather than erroring.
- Handlers now read request state from `$_POST`.
- `plan.js` `fetchJson` sends `method: 'POST'`, `Content-Type: application/x-www-form-urlencoded;charset=UTF-8`, with a `URLSearchParams` body carrying planner state + nonce. The `?action=...` stays in the URL so the server-side `$_GET['action']` dispatch still fires.
- The no-JS `<form method="get">` fallback is unaffected - it targets the full-page render, not the JSON endpoints.

## Test plan
- [x] `php -l index.php` - no syntax errors.
- [x] `GET /?action=dkc_plan_browse` returns `HTTP 200` and renders the page (action ignored on GET).
- [x] `POST /?action=dkc_plan_browse` without a nonce returns `HTTP 403` with the planner verification error.

Part of a series addressing the findings documented at `.claude/SECURITY_REVIEW.md` locally.
