### PR TITLE
Security: optional DKC_PLAN_BASE_URL override for HTTP_HOST (L4)

### DIFF
--- a/c88e3e98.example.php
+++ b/c88e3e98.example.php
@@ -30,3 +30,13 @@ if (!defined('DKC_PLAN_STANDALONE_BOOTSTRAP')) {
 if (!defined('DKC_PLAN_GOOGLE_API_KEY')) {
 	define('DKC_PLAN_GOOGLE_API_KEY', '');
 }
+
+/*
+ * Optional: pin the canonical base URL used for form actions and
+ * self-referential links. This hardens the planner against
+ * Host-header poisoning when the site sits behind a shared cache.
+ *
+ * if (!defined('DKC_PLAN_BASE_URL')) {
+ *     define('DKC_PLAN_BASE_URL', 'https://example.com/plan-your-day/');
+ * }
+ */

--- a/index.php
+++ b/index.php
@@ -470,6 +470,18 @@ if (!function_exists('dkc_plan_current_url')) {
 	 */
 	function dkc_plan_current_url(): string
 	{
+		$configured = '';
+
+		if (defined('DKC_PLAN_BASE_URL')) {
+			$configured = (string) DKC_PLAN_BASE_URL;
+		}
+
+		$configured = (string) apply_filters('dkc_plan_base_url', $configured);
+
+		if ('' !== $configured) {
+			return rtrim($configured, '/');
+		}
+
 		$is_https = !empty($_SERVER['HTTPS']) && 'off' !== strtolower((string) $_SERVER['HTTPS']);
 		$scheme = $is_https ? 'https' : 'http';
 		$host = (string) ($_SERVER['HTTP_HOST'] ?? 'localhost');


### PR DESCRIPTION
## Summary
- `dkc_plan_current_url` derived the canonical planner URL from `$_SERVER['HTTP_HOST']`, which is attacker-controllable via the `Host` header.
- Behind a shared cache or misconfigured proxy, Host-header poisoning can cause form actions and self-referential links to point at a host the site operator never intended.

## Fix
- Add an optional `DKC_PLAN_BASE_URL` constant that, when defined non-empty, pins the base URL and bypasses the `HTTP_HOST`-derived logic.
- Add a matching `dkc_plan_base_url` filter (applied even if the constant is unset) so a filter-only config path works too.
- `rtrim($configured, '/')` keeps URL composition clean if the configured value ends with `/`.
- When unset, behavior is unchanged: scheme + `HTTP_HOST` + derived path.
- `c88e3e98.example.php` documents the opt-in as a commented-out `define()`.

## Test plan
- [x] `php -l index.php` → no syntax errors.
- [x] `php -l c88e3e98.example.php` → no syntax errors.
- [ ] With `DKC_PLAN_BASE_URL` unset, full-page render produces the same action URL as before.
- [ ] With `DKC_PLAN_BASE_URL` set to `https://example.com/plan-your-day/`, render produces `https://example.com/plan-your-day` (no trailing slash, constant wins over poisoned Host header).
- [ ] With only a `dkc_plan_base_url` filter attached, filter value wins over Host header.

Part of a series addressing the findings documented at .claude/SECURITY_REVIEW.md locally.
