### PR TITLE
Polish: Allow: POST on 405 + CSRF layering doc (M2 follow-up)

### DIFF
--- a/index.php
+++ b/index.php
@@ -1771,10 +1771,17 @@ if (!function_exists('dkc_plan_validate_ajax_request')) {
 	 * The planner remains public, but these checks prevent routine cross-site
 	 * requests and keep one visitor from triggering unbounded Google API work
 	 * through the focused AJAX endpoints.
+	 *
+	 * The POST requirement is layered hygiene — it filters out browser
+	 * prefetches, link-preview bots, and <img src> drive-by requests.
+	 * The nonce check is the actual CSRF defense: without it, any same-
+	 * origin page could form-POST to these endpoints. Do not remove the
+	 * nonce check on the assumption that POST-only is sufficient.
 	 */
 	function dkc_plan_validate_ajax_request(string $scope): void
 	{
 		if ('POST' !== (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+			header('Allow: POST');
 			wp_send_json_error(
 				[
 					'message' => 'Planner endpoints require POST.',

--- a/index.php
+++ b/index.php
@@ -1893,6 +1893,14 @@ if ('dkc_plan_browse' === $planner_endpoint_action || 'dkc_plan_route' === $plan
 		} else {
 			dkc_plan_handle_route_request();
 		}
+	} elseif ('GET' !== (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+		header('Allow: POST');
+		wp_send_json_error(
+			[
+				'message' => 'Planner endpoints require POST.',
+			],
+			405
+		);
 	}
 }
 

--- a/index.php
+++ b/index.php
@@ -1774,7 +1774,16 @@ if (!function_exists('dkc_plan_validate_ajax_request')) {
 	 */
 	function dkc_plan_validate_ajax_request(string $scope): void
 	{
-		$nonce = isset($_GET['nonce']) ? sanitize_text_field(wp_unslash((string) $_GET['nonce'])) : '';
+		if ('POST' !== (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+			wp_send_json_error(
+				[
+					'message' => 'Planner endpoints require POST.',
+				],
+				405
+			);
+		}
+
+		$nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash((string) $_POST['nonce'])) : '';
 
 		if (!wp_verify_nonce($nonce, 'dkc_plan_ajax')) {
 			wp_send_json_error(
@@ -1812,7 +1821,7 @@ if (!function_exists('dkc_plan_handle_browse_request')) {
 	{
 		dkc_plan_validate_ajax_request('browse');
 
-		$request_args = dkc_plan_get_request_state_args($_GET);
+		$request_args = dkc_plan_get_request_state_args($_POST);
 		$planner_state = dkc_plan_build_runtime_state(
 			$request_args,
 			[
@@ -1840,7 +1849,7 @@ if (!function_exists('dkc_plan_handle_route_request')) {
 	{
 		dkc_plan_validate_ajax_request('route');
 
-		$request_args = dkc_plan_get_request_state_args($_GET);
+		$request_args = dkc_plan_get_request_state_args($_POST);
 		$planner_state = dkc_plan_build_runtime_state(
 			$request_args,
 			[
@@ -1867,12 +1876,17 @@ if (!function_exists('dkc_plan_handle_route_request')) {
  */
 $planner_endpoint_action = isset($_GET['action']) ? sanitize_key(wp_unslash((string) $_GET['action'])) : '';
 
-if ('dkc_plan_browse' === $planner_endpoint_action) {
-	dkc_plan_handle_browse_request();
-}
-
-if ('dkc_plan_route' === $planner_endpoint_action) {
-	dkc_plan_handle_route_request();
+if ('dkc_plan_browse' === $planner_endpoint_action || 'dkc_plan_route' === $planner_endpoint_action) {
+	// These are exclusively POST endpoints now. A stray GET on the
+	// action= query parameter during a full-page navigation should just
+	// render the page (ignore the action), not error out.
+	if ('POST' === (string) ($_SERVER['REQUEST_METHOD'] ?? '')) {
+		if ('dkc_plan_browse' === $planner_endpoint_action) {
+			dkc_plan_handle_browse_request();
+		} else {
+			dkc_plan_handle_route_request();
+		}
+	}
 }
 
 $planner_section_id         = 'dkc-plan-your-day';

--- a/plan.js
+++ b/plan.js
@@ -243,11 +243,17 @@
   const buildAjaxUrl = (action) => {
     const nextUrl = new URL(config.ajaxUrl || window.location.pathname, window.location.origin);
     nextUrl.searchParams.set('action', action);
-    if (config.ajaxNonce) {
-      nextUrl.searchParams.set('nonce', config.ajaxNonce);
-    }
-    appendStateToSearchParams(nextUrl.searchParams, getCurrentPlannerState());
     return nextUrl;
+  };
+
+  const buildAjaxBody = (action) => {
+    const body = new URLSearchParams();
+    appendStateToSearchParams(body, getCurrentPlannerState());
+    body.set('action', action);
+    if (config.ajaxNonce) {
+      body.set('nonce', config.ajaxNonce);
+    }
+    return body;
   };
 
   const syncUrl = () => {
@@ -1018,12 +1024,15 @@
     renderAll();
   };
 
-  const fetchJson = async (scope, url, controller) => {
+  const fetchJson = async (scope, url, body, controller) => {
     const response = await window.fetch(url.toString(), {
+      method: 'POST',
       credentials: 'same-origin',
       headers: {
         Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       },
+      body,
       signal: controller.signal,
       cache: 'no-store',
     });
@@ -1121,9 +1130,11 @@
     }
 
     try {
+      const browseAction = config.endpoints?.browseAction || 'dkc_plan_browse';
       const responseData = await fetchJson(
         'browse',
-        buildAjaxUrl(config.endpoints?.browseAction || 'dkc_plan_browse'),
+        buildAjaxUrl(browseAction),
+        buildAjaxBody(browseAction),
         browseRequestController
       );
 
@@ -1175,9 +1186,11 @@
     });
 
     try {
+      const routeAction = config.endpoints?.routeAction || 'dkc_plan_route';
       const responseData = await fetchJson(
         'route',
-        buildAjaxUrl(config.endpoints?.routeAction || 'dkc_plan_route'),
+        buildAjaxUrl(routeAction),
+        buildAjaxBody(routeAction),
         routeRequestController
       );
 


### PR DESCRIPTION
## Summary
Follow-up to #10 (M2 POST-only endpoints) addressing two Minor items from code review:

- **RFC 7231 compliance**: non-GET/non-POST requests to planner JSON actions now return 405 with `Allow: POST`.
- **GET compatibility**: stray GETs with `?action=dkc_plan_*` still fall through to the full-page render, matching #10's behavior.
- **Docblock**: clarifies that POST-only is layered hygiene and the nonce is the actual CSRF defense.

## Depends on
#10 — branch cut from `fix/m2-post-only-endpoints`. Rebases cleanly after #10 merges.

## Test plan
- [x] `php -l index.php` clean.
- [x] `curl -si -X GET /index.php?action=dkc_plan_browse` still returns 200 full-page render, with no `Allow` header.
- [x] `curl -si -X OPTIONS /index.php?action=dkc_plan_browse` returns 405 with `Allow: POST`.
