### PR TITLE
Polish: update wp_json_encode docblock (M4 follow-up)

### DIFF
--- a/index.php
+++ b/index.php
@@ -74,7 +74,7 @@ if (!function_exists('wp_json_encode')) {
 	{
 		$encoded = json_encode(
 			$value,
-			JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+			JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE | JSON_HEX_TAG
 		);
 
 		return false === $encoded ? 'null' : $encoded;

--- a/index.php
+++ b/index.php
@@ -67,8 +67,13 @@ if (!function_exists('wp_json_encode')) {
 	/**
 	 * Encode data for HTML script blocks, cache keys, and JSON responses.
 	 *
-	 * The flags match the behavior the planner needs most: readable URLs and
-	 * safe handling of invalid UTF-8 instead of failing silently.
+	 * JSON_HEX_TAG encodes `<` and `>` as `\u003C` / `\u003E` so values
+	 * sourced from third parties (Google place names) cannot terminate the
+	 * `<script type="application/json">` config blob. Dropping
+	 * JSON_UNESCAPED_SLASHES additionally escapes `/` to `\/` as defense in
+	 * depth. JSON_UNESCAPED_UNICODE keeps non-ASCII characters readable in
+	 * the rendered source. JSON_INVALID_UTF8_SUBSTITUTE tolerates bad bytes
+	 * instead of returning false.
 	 */
 	function wp_json_encode($value): string
 	{


### PR DESCRIPTION
## Summary
Follow-up to #4 (M4 — neutralize `</script>` in JSON blob). The `wp_json_encode` shim's docblock described the old (pre-M4) flag rationale ("readable URLs"). Refresh to describe the current security-motivated flag set and explain what each flag does.

No behavior change.

## Depends on
#4 — branch cut from `fix/m4-json-escape-slashes`.
