### PR TITLE
Polish: tighten display_errors comment wording (L5 follow-up)

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,6 +11,16 @@ declare(strict_types=1);
  */
 
 /*
+ * Never leak PHP errors to HTTP responses. Deployment-level
+ * php.ini may override this, but the default for this planner
+ * is to log only — any runtime notice or warning would otherwise
+ * corrupt JSON endpoint responses and expose local paths.
+ */
+@ini_set('display_errors', '0');
+@ini_set('display_startup_errors', '0');
+error_reporting(E_ALL);
+
+/*
  * Load the standalone Google Maps API key from a separate local PHP config.
  *
  * A .php config file is safer than .inc on this Apache/PHP stack because it is

--- a/index.php
+++ b/index.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
  */
 
 /*
- * Never leak PHP errors to HTTP responses. Deployment-level
- * php.ini may override this, but the default for this planner
- * is to log only — any runtime notice or warning would otherwise
+ * Never leak PHP errors to HTTP responses. An operator who wants
+ * browser-visible errors back on for debugging can still enable
+ * them explicitly via php.ini or php_admin_value; the defaults
+ * here are log-only. Any runtime notice or warning would otherwise
  * corrupt JSON endpoint responses and expose local paths.
  */
 @ini_set('display_errors', '0');


### PR DESCRIPTION
## Summary
Follow-up to #9 (L5 — disable display_errors at bootstrap). The original comment's "php.ini may override this" phrasing was ambiguous about the direction of override. Rewrite to make explicit: operators can intentionally re-enable browser-visible errors for debugging via php.ini / php_admin_value; the default here is log-only.

No behavior change.

## Depends on
#9 — branch cut from `fix/l5-disable-display-errors`.
