### PR TITLE
Polish: comment JS safeHttpsUrl rationale (M3 follow-up)

### DIFF
--- a/index.php
+++ b/index.php
@@ -161,6 +161,22 @@ if (!function_exists('esc_url')) {
 	}
 }
 
+if (!function_exists('dkc_plan_safe_https_url')) {
+	/**
+	 * Return the input only if it is a plain https:// URL.
+	 *
+	 * Used for externally sourced URL fields (currently Google's
+	 * googleMapsUri). Defends against an upstream ever returning a
+	 * non-https scheme — e.g. javascript: — landing in an href.
+	 */
+	function dkc_plan_safe_https_url(string $url): string
+	{
+		$url = trim($url);
+
+		return 1 === preg_match('#\Ahttps://[^\s<>"\']+\z#i', $url) ? $url : '';
+	}
+}
+
 if (!function_exists('checked')) {
 	/**
 	 * Echo a checked attribute when two values match.
@@ -813,7 +829,7 @@ if (!function_exists('dkc_plan_parse_google_place')) {
 		$place_id  = dkc_plan_sanitize_place_id((string) ($place['id'] ?? ''));
 		$label     = trim((string) ($place['displayName']['text'] ?? ''));
 		$address   = trim((string) ($place['formattedAddress'] ?? ''));
-		$maps_uri  = trim((string) ($place['googleMapsUri'] ?? ''));
+		$maps_uri  = dkc_plan_safe_https_url((string) ($place['googleMapsUri'] ?? ''));
 		$latitude  = isset($place['location']['latitude']) ? (float) $place['location']['latitude'] : null;
 		$longitude = isset($place['location']['longitude']) ? (float) $place['location']['longitude'] : null;
 

--- a/plan.js
+++ b/plan.js
@@ -208,6 +208,13 @@
 
   const escapeAttr = (value) => escapeHtml(value);
 
+  // Belt-and-suspenders mirror of the PHP dkc_plan_safe_https_url() helper.
+  // The server already filters Google's googleMapsUri at parse time, so this
+  // check is redundant in normal operation. It defends against a future
+  // code path that renders an externally-sourced URL directly in JS without
+  // going through the server filter — if Google ever returned a non-https
+  // scheme (e.g. javascript:), escapeAttr() alone would not block it from
+  // landing in an href attribute.
   const safeHttpsUrl = (value) =>
     /^https:\/\/[^\s<>"']+$/i.test(String(value ?? '')) ? String(value) : '';
 

--- a/plan.js
+++ b/plan.js
@@ -208,6 +208,9 @@
 
   const escapeAttr = (value) => escapeHtml(value);
 
+  const safeHttpsUrl = (value) =>
+    /^https:\/\/[^\s<>"']+$/i.test(String(value ?? '')) ? String(value) : '';
+
   const getCurrentPlannerState = () => ({
     category: state.browse.activeCategoryKey,
     selectedWaypointIds: [...state.trip.selectedWaypointIds],
@@ -680,9 +683,9 @@
                 </div>
                 <div class="dkc-plan__result-tools">
                   ${
-                    result.maps_uri
+                    safeHttpsUrl(result.maps_uri)
                       ? `<a class="dkc-plan__result-link" href="${escapeAttr(
-                          result.maps_uri
+                          safeHttpsUrl(result.maps_uri)
                         )}" target="_blank" rel="noopener noreferrer">View in Google Maps</a>`
                       : ''
                   }


### PR DESCRIPTION
## Summary
Follow-up to #8 (M3 — https:// URL allowlist). Adds an inline comment above the JS `safeHttpsUrl` helper explaining why it's belt-and-suspenders alongside the server-side filter. Prevents a future reader from removing "redundant" client-side validation and reopening the vector if any future code path renders an externally-sourced URL directly in JS without passing through `parse_google_place`.

No behavior change.

## Depends on
#8 — branch cut from `fix/m3-https-url-allowlist`. PR diff shows #8's commits plus this polish commit until #8 merges; once #8 lands, this PR auto-narrows to the polish diff only.
