### PR TITLE
Scaffold generic Plan Your Day plugin (#20)

### DIFF
--- a/plugin/plan-your-day/.distignore
+++ b/plugin/plan-your-day/.distignore
@@ -1,0 +1,16 @@
+# Files excluded from the release zip build.
+# Release pipeline runs `composer install --no-dev --optimize-autoloader`
+# (and prefix-scoping, once introduced) before zipping.
+
+/.distignore
+/.git
+/.gitignore
+/.github
+/composer.json
+/composer.lock
+/node_modules
+/tests
+/phpunit.xml
+/phpunit.xml.dist
+/DECISIONS.md
+/*.log

--- a/plugin/plan-your-day/.distignore
+++ b/plugin/plan-your-day/.distignore
@@ -1,13 +1,12 @@
 # Files excluded from the release zip build.
 # Release pipeline runs `composer install --no-dev --optimize-autoloader`
-# (and prefix-scoping, once introduced) before zipping.
+# (and prefix-scoping, once introduced) before zipping, then verifies
+# `vendor/autoload.php` exists in the artifact.
 
 /.distignore
 /.git
 /.gitignore
 /.github
-/composer.json
-/composer.lock
 /node_modules
 /tests
 /phpunit.xml

--- a/plugin/plan-your-day/DECISIONS.md
+++ b/plugin/plan-your-day/DECISIONS.md
@@ -11,19 +11,23 @@ repo). Each decision can be revisited when that milestone's recommendation
 
 ## 1. Autoloader — Composer PSR-4
 
-- `composer.json` declares `"psr-4": { "PlanYourDay\\": "src/" }`.
-- Main plugin file requires `vendor/autoload.php`; bails silently with a
-  comment if missing (dev clone hasn't run `composer install` yet).
+- `composer.json` declares `"psr-4": { "Acodebeard\\PlanYourDay\\": "src/" }`.
+- Main plugin file requires `vendor/autoload.php`; if missing, activation fails
+  visibly and active installs show an admin notice.
 - `vendor/` is gitignored at the source-repo root. Release pipeline runs
   `composer install --no-dev --optimize-autoloader` before zipping.
+- Built release zips include generated Composer autoload files and Composer
+  metadata; target sites should not need to run Composer.
 - Enables Strauss / PHP-Scoper dep prefix-scoping later without a rename
   migration (PITFALLS.md B2).
 
-## 2. Namespace shape — hybrid
+## 2. Namespace shape — vendor-prefixed hybrid
 
-- Root namespace `PlanYourDay\` holds `Activator`, `Deactivator`, `Plugin`.
+- Root namespace `Acodebeard\PlanYourDay\` holds `Activator`, `Deactivator`,
+  `Plugin`.
 - Subpackages (`\Http`, `\Google`, `\Rest`, `\Admin`, `\Core`) added as the
   first class of each domain lands — not reserved speculatively.
+- The vendor prefix reduces collision risk in WordPress' shared PHP runtime.
 - Matches research ARCHITECTURE.md layering without locking it in before we
   have second-class data.
 
@@ -35,12 +39,14 @@ repo). Each decision can be revisited when that milestone's recommendation
 - Closes PITFALLS.md B11 (deactivate vs uninstall bracket) while the state
   surface is still small enough to be obvious.
 
-## 4. i18n — `load_plugin_textdomain` on `plugins_loaded` priority 10
+## 4. i18n — `load_plugin_textdomain` on `init` priority 0
 
 - Registered by `Plugin::init()` via `add_action`.
-- Ensures `__()` / `_e()` work from `plugins_loaded`-or-later hooks.
-- Canonical WP pattern; prevents PITFALLS.md B8 (strings before textdomain
-  load return raw).
+- WordPress 6.7+ warns when translations are loaded too early. Manual textdomain
+  loading should happen at `init` or later, or be omitted for WordPress.org
+  plugins that rely on just-in-time translation loading.
+- Using `init` priority 0 keeps the scaffold ready for custom language files
+  without encouraging translation calls before WordPress knows the current user.
 
 ## 5. PHP / WordPress floors — PHP 8.2 / WP 6.8
 

--- a/plugin/plan-your-day/DECISIONS.md
+++ b/plugin/plan-your-day/DECISIONS.md
@@ -1,0 +1,69 @@
+# Scaffold Decisions
+
+Decisions frozen at issue #20 scaffold commit. Each is a one-way door in the
+PITFALLS.md D5 sense — renaming namespaces, swapping autoloaders, or retrofitting
+uninstall routines is doable but churny once classes multiply.
+
+Rationale references cited are from the discovery milestone's research set
+(lives in the companion `plan-ur-day-docs` planning repo, not this source
+repo). Each decision can be revisited when that milestone's recommendation
+(`REC-02`) lands.
+
+## 1. Autoloader — Composer PSR-4
+
+- `composer.json` declares `"psr-4": { "PlanYourDay\\": "src/" }`.
+- Main plugin file requires `vendor/autoload.php`; bails silently with a
+  comment if missing (dev clone hasn't run `composer install` yet).
+- `vendor/` is gitignored at the source-repo root. Release pipeline runs
+  `composer install --no-dev --optimize-autoloader` before zipping.
+- Enables Strauss / PHP-Scoper dep prefix-scoping later without a rename
+  migration (PITFALLS.md B2).
+
+## 2. Namespace shape — hybrid
+
+- Root namespace `PlanYourDay\` holds `Activator`, `Deactivator`, `Plugin`.
+- Subpackages (`\Http`, `\Google`, `\Rest`, `\Admin`, `\Core`) added as the
+  first class of each domain lands — not reserved speculatively.
+- Matches research ARCHITECTURE.md layering without locking it in before we
+  have second-class data.
+
+## 3. `uninstall.php` — ships with scaffold
+
+- Brackets the two options the Activator creates
+  (`plan_your_day_version`, `plan_your_day_schema_version`).
+- Guarded by `defined( 'WP_UNINSTALL_PLUGIN' ) || exit`.
+- Closes PITFALLS.md B11 (deactivate vs uninstall bracket) while the state
+  surface is still small enough to be obvious.
+
+## 4. i18n — `load_plugin_textdomain` on `plugins_loaded` priority 10
+
+- Registered by `Plugin::init()` via `add_action`.
+- Ensures `__()` / `_e()` work from `plugins_loaded`-or-later hooks.
+- Canonical WP pattern; prevents PITFALLS.md B8 (strings before textdomain
+  load return raw).
+
+## 5. PHP / WordPress floors — PHP 8.2 / WP 6.8
+
+- Diverges from the plan file's 8.1 / 6.4 targets.
+- PHP 8.1 reached end-of-life in December 2025; 8.2 is the oldest actively
+  supported line.
+- WP 6.8 matches `@wordpress/scripts` and block-editor feature availability
+  (`viewScriptModule`, interactivity API) needed by subsequent port issues.
+- **Revisit gate:** DOC-03 of the discovery milestone runs PHPCompatibilityWP
+  against the standalone `index.php`. If it surfaces constructs requiring
+  newer-than-8.2 features, fine — we're already right. If it surfaces
+  backward-compat needs against older hosts, the scaffold's headers drop back
+  to the plan's 8.1 / 6.4 values. No work lost either way at this stage.
+
+## What is deliberately deferred (not silent prereqs — noted here)
+
+- **Multisite posture** (PITFALLS.md B7). Scaffold uses `register_activation_hook`
+  (single-site). Network-activation semantics decided in the issue that
+  introduces the first multisite-relevant state (options or custom tables).
+- **Capabilities / nonces / REST namespace.** None of these yet; no endpoints
+  in the scaffold. Decided alongside the first admin screen or REST route
+  (GH issues 22+).
+- **Test harness (`phpunit.xml.dist`, `tests/`).** Noted in issue tracker —
+  belongs in a dedicated CI/testing issue, not hidden inside scaffold.
+- **Update URI header.** Correctly deferred by the plan file until
+  distribution channel is decided (REC-02 adjacent).

--- a/plugin/plan-your-day/composer.json
+++ b/plugin/plan-your-day/composer.json
@@ -8,7 +8,7 @@
     },
     "autoload": {
         "psr-4": {
-            "PlanYourDay\\": "src/"
+            "Acodebeard\\PlanYourDay\\": "src/"
         }
     }
 }

--- a/plugin/plan-your-day/composer.json
+++ b/plugin/plan-your-day/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "acodebeard/plan-your-day",
+    "description": "A configurable day planning plugin for WordPress.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "PlanYourDay\\": "src/"
+        }
+    }
+}

--- a/plugin/plan-your-day/plan-your-day.php
+++ b/plugin/plan-your-day/plan-your-day.php
@@ -25,12 +25,41 @@ define( 'PLAN_YOUR_DAY_TEXT_DOMAIN', 'plan-your-day' );
 
 $plan_your_day_autoload = PLAN_YOUR_DAY_PLUGIN_DIR . 'vendor/autoload.php';
 if ( ! is_readable( $plan_your_day_autoload ) ) {
-	// Dev setup: run `composer install` inside the plugin directory.
+	register_activation_hook( __FILE__, 'plan_your_day_missing_autoloader_activation' );
+	add_action( 'admin_notices', 'plan_your_day_missing_autoloader_admin_notice' );
 	return;
 }
 require_once $plan_your_day_autoload;
 
-register_activation_hook( __FILE__, [ \PlanYourDay\Activator::class, 'activate' ] );
-register_deactivation_hook( __FILE__, [ \PlanYourDay\Deactivator::class, 'deactivate' ] );
+register_activation_hook( __FILE__, [ \Acodebeard\PlanYourDay\Activator::class, 'activate' ] );
+register_deactivation_hook( __FILE__, [ \Acodebeard\PlanYourDay\Deactivator::class, 'deactivate' ] );
 
-\PlanYourDay\Plugin::instance()->init();
+\Acodebeard\PlanYourDay\Plugin::instance()->init();
+
+function plan_your_day_missing_autoloader_message(): string {
+	return 'Plan Your Day is missing Composer dependencies. Install a built release zip that includes vendor/autoload.php, '
+		. 'or run composer install inside the plugin directory for a source checkout.';
+}
+
+function plan_your_day_missing_autoloader_activation(): void {
+	if ( function_exists( 'deactivate_plugins' ) ) {
+		deactivate_plugins( plugin_basename( __FILE__ ) );
+	}
+
+	wp_die(
+		esc_html( plan_your_day_missing_autoloader_message() ),
+		esc_html( 'Plan Your Day activation failed' ),
+		[ 'back_link' => true ]
+	);
+}
+
+function plan_your_day_missing_autoloader_admin_notice(): void {
+	if ( ! current_user_can( 'activate_plugins' ) ) {
+		return;
+	}
+
+	printf(
+		'<div class="notice notice-error"><p>%s</p></div>',
+		esc_html( plan_your_day_missing_autoloader_message() )
+	);
+}

--- a/plugin/plan-your-day/plan-your-day.php
+++ b/plugin/plan-your-day/plan-your-day.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: Plan Your Day
+ * Description: A configurable day planning plugin for WordPress.
+ * Version: 0.1.0
+ * Requires at least: 6.8
+ * Requires PHP: 8.2
+ * Author: acodebeard
+ * Text Domain: plan-your-day
+ * Domain Path: /languages
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'PLAN_YOUR_DAY_VERSION', '0.1.0' );
+define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 1 );
+define( 'PLAN_YOUR_DAY_PLUGIN_FILE', __FILE__ );
+define( 'PLAN_YOUR_DAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'PLAN_YOUR_DAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+define( 'PLAN_YOUR_DAY_TEXT_DOMAIN', 'plan-your-day' );
+
+$plan_your_day_autoload = PLAN_YOUR_DAY_PLUGIN_DIR . 'vendor/autoload.php';
+if ( ! is_readable( $plan_your_day_autoload ) ) {
+	// Dev setup: run `composer install` inside the plugin directory.
+	return;
+}
+require_once $plan_your_day_autoload;
+
+register_activation_hook( __FILE__, [ \PlanYourDay\Activator::class, 'activate' ] );
+register_deactivation_hook( __FILE__, [ \PlanYourDay\Deactivator::class, 'deactivate' ] );
+
+\PlanYourDay\Plugin::instance()->init();

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -16,7 +16,14 @@ Placeholder. Plugin scaffold only — functional features land in subsequent iss
 
 == Installation ==
 
-1. Upload the `plan-your-day` directory to `/wp-content/plugins/`.
+Release zip:
+
+1. Upload the built `plan-your-day` release zip through the Plugins screen in WordPress.
+2. Activate the plugin. Release zips include generated Composer autoload files.
+
+Source checkout:
+
+1. Copy the `plan-your-day` directory to `/wp-content/plugins/`.
 2. Run `composer install` inside the plugin directory to generate the autoloader.
 3. Activate the plugin through the Plugins screen in WordPress.
 

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -1,0 +1,32 @@
+=== Plan Your Day ===
+Contributors: acodebeard
+Tags: planning, maps, wayfinding
+Requires at least: 6.8
+Tested up to: 6.8
+Requires PHP: 8.2
+Stable tag: 0.1.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A configurable day planning plugin for WordPress.
+
+== Description ==
+
+Placeholder. Plugin scaffold only — functional features land in subsequent issues.
+
+== Installation ==
+
+1. Upload the `plan-your-day` directory to `/wp-content/plugins/`.
+2. Run `composer install` inside the plugin directory to generate the autoloader.
+3. Activate the plugin through the Plugins screen in WordPress.
+
+== Frequently Asked Questions ==
+
+= Is this ready for production? =
+
+No. This is an initial scaffold; features are introduced through the issue tracker.
+
+== Changelog ==
+
+= 0.1.0 =
+* Initial plugin scaffold (GH issue #20): directory structure, main plugin file, activation / deactivation hooks, uninstall routine, PSR-4 autoloading.

--- a/plugin/plan-your-day/release.json
+++ b/plugin/plan-your-day/release.json
@@ -1,0 +1,9 @@
+{
+    "name": "Plan Your Day",
+    "slug": "plan-your-day",
+    "version": "0.1.0",
+    "schemaVersion": 1,
+    "artifact": null,
+    "distribution": "undecided",
+    "notes": "Initial scaffold. Distribution channel (WP.org directory, self-hosted, or both) not yet decided."
+}

--- a/plugin/plan-your-day/src/Activator.php
+++ b/plugin/plan-your-day/src/Activator.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace PlanYourDay;
+namespace Acodebeard\PlanYourDay;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/plugin/plan-your-day/src/Activator.php
+++ b/plugin/plan-your-day/src/Activator.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types=1 );
+
+namespace PlanYourDay;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Activator {
+	public static function activate(): void {
+		update_option( 'plan_your_day_version', PLAN_YOUR_DAY_VERSION );
+		update_option( 'plan_your_day_schema_version', PLAN_YOUR_DAY_SCHEMA_VERSION );
+	}
+}

--- a/plugin/plan-your-day/src/Deactivator.php
+++ b/plugin/plan-your-day/src/Deactivator.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace PlanYourDay;
+namespace Acodebeard\PlanYourDay;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/plugin/plan-your-day/src/Deactivator.php
+++ b/plugin/plan-your-day/src/Deactivator.php
@@ -1,0 +1,13 @@
+<?php
+declare( strict_types=1 );
+
+namespace PlanYourDay;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Deactivator {
+	public static function deactivate(): void {
+		// Intentionally non-destructive.
+		// Cleanup of plugin state (options, scheduled events) happens in uninstall.php.
+	}
+}

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace PlanYourDay;
+namespace Acodebeard\PlanYourDay;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,7 +18,7 @@ final class Plugin {
 	private function __construct() {}
 
 	public function init(): void {
-		add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+		add_action( 'init', [ $this, 'load_textdomain' ], 0 );
 	}
 
 	public function load_textdomain(): void {

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace PlanYourDay;
+
+defined( 'ABSPATH' ) || exit;
+
+final class Plugin {
+	private static ?Plugin $instance = null;
+
+	public static function instance(): Plugin {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {}
+
+	public function init(): void {
+		add_action( 'plugins_loaded', [ $this, 'load_textdomain' ] );
+	}
+
+	public function load_textdomain(): void {
+		load_plugin_textdomain(
+			PLAN_YOUR_DAY_TEXT_DOMAIN,
+			false,
+			dirname( plugin_basename( PLAN_YOUR_DAY_PLUGIN_FILE ) ) . '/languages'
+		);
+	}
+}

--- a/plugin/plan-your-day/uninstall.php
+++ b/plugin/plan-your-day/uninstall.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Uninstall routine — removes plugin-scoped options created by the Activator.
+ * Runs only when an administrator explicitly uninstalls the plugin.
+ */
+
+declare( strict_types=1 );
+
+defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
+
+delete_option( 'plan_your_day_version' );
+delete_option( 'plan_your_day_schema_version' );


### PR DESCRIPTION
## Summary

Closes #20. Adds the generic `plugin/plan-your-day/` scaffold with PSR-4 autoloading, activation / deactivation hooks, uninstall routine, and release-metadata placeholders. Standalone runtime (`index.php`, `plan.js`, `plan.css`, `icons/`) is untouched.

File tree:

```text
plugin/plan-your-day/
├── .distignore
├── DECISIONS.md
├── composer.json
├── plan-your-day.php
├── readme.txt
├── release.json
├── uninstall.php
└── src/
    ├── Activator.php
    ├── Deactivator.php
    └── Plugin.php
```

## Divergences from the plan document

The plan left several scaffold decisions implicit. They are recorded in `plugin/plan-your-day/DECISIONS.md` with rationale.

| # | Topic | Decision | Plan said |
|---|-------|----------|-----------|
| 1 | Autoloader | Composer PSR-4 with visible missing-autoloader failure | "Load classes from src/" (unspecified) |
| 2 | Namespace shape | Vendor-prefixed hybrid: `Acodebeard\PlanYourDay\` | Flat `PlanYourDay\` |
| 3 | `uninstall.php` | Ships and deletes the two options Activator creates | Not in file list |
| 4 | i18n hook | `load_plugin_textdomain` on `init` priority 0 | Not addressed |
| 5 | PHP / WP floor | **PHP 8.2 / WP 6.8** | PHP 8.1 / WP 6.4 |

The PHP/WP floor divergence (#5) is the one worth calling out: PHP 8.1 reached end-of-life in December 2025, so 8.2 is the oldest actively supported line. WP 6.8 aligns with current `@wordpress/scripts` and block-editor features (`viewScriptModule`, interactivity API) likely needed by downstream issues. If a specific deploy target constrains the floor lower, `DECISIONS.md §5` flags the revisit gate; reverting to the plan's values is a one-commit change.

## Review follow-up included

- Moved manual i18n loading from `plugins_loaded` to `init` priority 0 for WP 6.7+/6.8 timing guidance.
- Vendor-prefixed the PHP namespace to reduce collision risk in WordPress' shared runtime.
- Replaced the silent missing-autoloader return with an activation failure path and admin notice.
- Split release zip install instructions from source checkout Composer instructions.
- Kept Composer metadata in release artifacts and documented a release check for `vendor/autoload.php`.

## Test plan

- [x] `find plugin/plan-your-day -name '*.php' -exec php -l {} \;` — returns 0 for every file
- [x] `rg "Kona|Destination Kona Coast|Kailua Pier|DKC|dkc" plugin/plan-your-day` — zero matches
- [x] `cd plugin/plan-your-day && composer validate --no-check-publish --strict` — succeeds
- [x] Temp-copy `composer install --no-interaction --no-progress`, then require `vendor/autoload.php` and confirm `Acodebeard\\PlanYourDay\\Plugin` autoloads
- [ ] Symlink or copy `plugin/plan-your-day/` to a local `wp-content/plugins/plan-your-day/`; activate in WP admin — activation succeeds, no fatals, no PHP notices
- [ ] Confirm `plan_your_day_version` and `plan_your_day_schema_version` appear in `wp_options` after activation
- [ ] Deactivate — options remain (non-destructive deactivation)
- [ ] Uninstall via Plugins → Delete — options are removed from `wp_options`
- [ ] Standalone `index.php` still serves the planner UI unchanged

Note: the local Composer binary emits deprecation notices from its own installed package set under the current PHP runtime, but validation and temp-copy autoload generation exit successfully.

## Notes for future issues

Deliberately deferred (documented in `DECISIONS.md` "What is deliberately deferred"):

- Multisite posture — decided alongside the first multisite-relevant state (options vs site-options) in a later issue
- Capabilities / nonces / REST namespace — none yet; decided when the first endpoint or admin screen lands (issues 22+)
- Test harness (`phpunit.xml.dist`, `tests/`) — belongs in a dedicated CI/testing issue, not inside scaffold
- `Update URI` header — per the plan, deferred until distribution channel is decided