### PR TITLE
[codex] Extract planner service helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Completed foundation work includes:
 - Google API client abstraction with server-side key handling, explicit field
   masks, safe result objects, configurable timeouts, and transient-backed
   caching.
+- Extracted planner helper services for place parsing, waypoint state, distance
+  labels, map URLs, start context, request state, and request-origin checks.
 
 Frontend rendering, REST endpoints, anonymous visitor token protection, asset
 enqueueing, migration helpers, CI, and production documentation are still tracked
@@ -49,6 +51,12 @@ in GitHub issues.
   notes.
 - Root-level `index.php`, `plan.css`, `plan.js`, `icons/`, and private key
   examples are legacy standalone assets used as migration reference.
+
+## Documentation
+
+Start with [docs/README.md](docs/README.md). Current docs cover installation,
+architecture, settings, security, and troubleshooting for the work implemented
+so far.
 
 ## Local Source Installation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,118 @@
+# Architecture
+
+Plan Your Day is migrating from a standalone PHP planner into a generic
+WordPress plugin. The standalone root files remain as migration reference until
+the plugin reaches feature parity.
+
+## Plugin Entry Point
+
+The main plugin file is:
+
+```text
+plugin/plan-your-day/plan-your-day.php
+```
+
+It defines plugin constants, requires `vendor/autoload.php`, registers
+activation/deactivation hooks, and boots `Acodebeard\PlanYourDay\Plugin`.
+
+## Current Layers
+
+Current plugin source lives under:
+
+```text
+plugin/plan-your-day/src/
+```
+
+Implemented layers:
+
+- `Plugin`: wires WordPress hooks and exposes shared collaborators.
+- `Activator` / `Deactivator`: manage activation/deactivation boundaries.
+- `Settings`: owns defaults, sanitization, option registration, and read access.
+- `Admin`: owns the settings screen, setup notices, and cache tools.
+- `Google`: owns provider HTTP calls, field masks, result objects, and caching.
+- `Planner`: owns extracted planner helpers from the standalone runtime.
+- `Security`: owns request/security helpers extracted from standalone behavior.
+
+## Settings And Admin
+
+Settings are registered under:
+
+```text
+plan_your_day_settings
+```
+
+The admin page is registered under:
+
+```text
+Settings > Plan Your Day
+```
+
+The admin screen currently exposes required default location fields, planner
+behavior settings, Google API keys, cache TTLs, rate-limit configuration, trusted
+proxy CIDRs, and a Google API cache clear tool.
+
+## Google API Layer
+
+The Google API layer uses:
+
+- `GoogleApiClientInterface`
+- `GoogleApiClient`
+- `CachedGoogleApiClient`
+- `GoogleApiCache`
+- `GoogleApiResult`
+- `WordPressGoogleHttpTransport`
+
+The client currently supports:
+
+- Places API (New) text search.
+- Places API (New) place details.
+- Geocoding API lookups, falling back to the Places key when a dedicated
+  Geocoding key is empty.
+- Explicit field masks.
+- Configurable request timeout.
+- Safe user-facing errors.
+- Transient-backed response caching.
+
+Server-side Places and Geocoding keys must remain server-side. The browser-facing
+Maps Embed key is separate.
+
+## Planner Services
+
+Planner helpers extracted so far:
+
+- `PlaceParser`: shapes Google place responses and sanitizes Place IDs / HTTPS
+  map URLs.
+- `WaypointList`: normalizes, deduplicates, caps, and reorders waypoint IDs.
+- `DistanceFormatter`: calculates straight-line distance hints and formats
+  labels in miles or kilometers.
+- `MapUrlBuilder`: builds Google Maps search, directions, and embed URLs.
+- `StartContextResolver`: resolves default/current/custom start behavior using
+  plugin settings instead of hardcoded destination defaults.
+- `RequestStateParser`: normalizes request-style category, start, and waypoint
+  state.
+
+These services are exposed from `Plugin` so future shortcode and REST work can
+share one implementation.
+
+## Security Helpers
+
+`RequestOriginValidator` contains the same-site request heuristic extracted from
+the standalone runtime. It checks Fetch Metadata headers when available and
+falls back to `Origin` / `Referer` host matching.
+
+Anonymous visitor token validation and rate limiter enforcement for WordPress
+REST endpoints are still planned.
+
+## Still In The Standalone Runtime
+
+The root-level standalone implementation still contains:
+
+- Full planner rendering.
+- Focused JSON endpoint dispatch.
+- Standalone WordPress compatibility shims.
+- Session-backed nonce/cache behavior.
+- Standalone request rate limiting.
+- Standalone frontend state assembly.
+
+Those pieces should move into plugin-native renderer, REST, security, and asset
+classes in later issue slices.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,93 @@
+# Installation
+
+## Requirements
+
+- WordPress 6.8 or newer.
+- PHP 8.2 or newer.
+- Composer for source checkouts.
+- Google Cloud keys for Maps Embed API, Places API (New), and optionally
+  Geocoding API.
+
+## Source Checkout Install
+
+The plugin source lives at:
+
+```text
+plugin/plan-your-day/
+```
+
+For local development, copy or symlink that directory into a WordPress install:
+
+```sh
+ln -s /path/to/plan-your-day/plugin/plan-your-day /path/to/wordpress/wp-content/plugins/plan-your-day
+```
+
+Generate the Composer autoloader from the plugin directory:
+
+```sh
+cd /path/to/plan-your-day/plugin/plan-your-day
+composer install
+```
+
+Then activate the plugin from the WordPress admin Plugins screen or with WP-CLI:
+
+```sh
+wp --path=/path/to/wordpress plugin activate plan-your-day
+```
+
+## Local DKC Test Install
+
+The current local target test install is:
+
+```text
+/opt/lampp/htdocs/dkc
+```
+
+The local plugin install is a symlink:
+
+```text
+/opt/lampp/htdocs/dkc/wp-content/plugins/plan-your-day
+  -> /opt/lampp/htdocs/plan-your-day/plugin/plan-your-day
+```
+
+Useful local commands:
+
+```sh
+sudo /opt/lampp/lampp start
+
+/opt/lampp/bin/php /usr/local/bin/wp \
+  --path=/opt/lampp/htdocs/dkc \
+  --url=http://localhost/dkc \
+  plugin status plan-your-day \
+  --allow-root
+```
+
+The admin settings screen is:
+
+```text
+http://localhost/dkc/wp-admin/options-general.php?page=plan-your-day
+```
+
+## Activation Effects
+
+Activation writes the current plugin and schema versions:
+
+- `plan_your_day_version`
+- `plan_your_day_schema_version`
+
+The plugin settings option is:
+
+- `plan_your_day_settings`
+
+The settings option is registered through the WordPress Settings API and is
+read through `Settings::get_all()`, which merges saved values with plugin
+defaults.
+
+## Release Zip Expectations
+
+Release zips should include generated Composer autoload files. Production sites
+should not need to run Composer.
+
+The source repository ignores `vendor/`, but the release artifact should include
+the built `vendor/autoload.php`. The plugin `.distignore` controls release zip
+exclusions separately from source control ignore rules.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,32 @@
+# Plan Your Day Documentation
+
+This directory documents the WordPress plugin migration as it exists today.
+The plugin is installable and has admin/settings, Google API, cache, and
+planner helper foundations. Public planner rendering, REST endpoints, assets,
+migration helpers, release builds, and production QA are still in progress.
+
+## Current Documents
+
+- [Installation](INSTALLATION.md): source checkout setup, local DKC install,
+  activation checks, and release zip expectations.
+- [Architecture](ARCHITECTURE.md): plugin layers, current service boundaries,
+  and what remains in the standalone runtime.
+- [Settings](SETTINGS.md): option name, settings groups, defaults, API keys,
+  planner behavior, cache, and advanced networking settings.
+- [Security](SECURITY.md): current key-handling, escaping, cache, origin, and
+  rate-limit posture.
+- [Troubleshooting](TROUBLESHOOTING.md): common local install and activation
+  problems.
+
+## Still Planned
+
+These topics are intentionally incomplete until their implementation issues
+land:
+
+- Editor and frontend usage documentation.
+- Shortcode and block instructions.
+- REST endpoint request/response reference.
+- Anonymous visitor token details.
+- Standalone migration helper documentation.
+- Release zip build process and changelog policy.
+- Production QA and accessibility notes.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Model
+
+This document covers the security behavior implemented so far and the pieces
+still planned for the WordPress plugin.
+
+## Current Key Handling
+
+Google keys are separated by use:
+
+- Maps Embed API key is browser-facing.
+- Places API key is server-side.
+- Geocoding API key is server-side and optional.
+
+Server-side keys are read by backend services and must not be emitted in
+frontend runtime config.
+
+## Current API Client Protections
+
+The Google API client:
+
+- Uses explicit Places API field masks.
+- Uses configurable request timeouts.
+- Returns safe user-facing messages instead of raw provider errors.
+- Avoids exposing API keys in transient cache keys.
+- Caches successful provider responses through WordPress transients.
+
+## Current Admin Protections
+
+The settings page:
+
+- Requires `manage_options`.
+- Uses the WordPress Settings API.
+- Uses WordPress nonces for the cache clear tool.
+- Escapes admin output.
+- Sanitizes every registered setting before saving.
+
+## Current Request-Origin Helper
+
+`RequestOriginValidator` implements a same-site heuristic for future public
+request handling:
+
+- Fetch Metadata headers are preferred when browsers send them.
+- Cross-site subresource requests are rejected.
+- User-activated top-level document navigations can still be allowed.
+- `Origin` and `Referer` fallbacks compare against the expected host and port.
+
+This helper is not yet wired to public REST routes because those routes do not
+exist yet.
+
+## Planned Public Endpoint Protections
+
+Still planned:
+
+- WordPress REST routes for browse and route preview requests.
+- POST-only route methods.
+- Request schemas and request-field sanitization.
+- Guest-safe visitor token cookie.
+- HMAC endpoint token generation and validation.
+- Object-cache-aware or file-backed rate limiter.
+- Trusted-proxy-aware client IP resolution.
+- Structured REST errors for bad requests and invalid tokens.
+
+The standalone runtime still contains session-backed endpoint protection and
+rate limiting. Those behaviors are migration reference, not the final plugin
+implementation.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,86 @@
+# Settings Reference
+
+Plan Your Day stores plugin configuration in:
+
+```text
+plan_your_day_settings
+```
+
+The settings group is also:
+
+```text
+plan_your_day_settings
+```
+
+Only administrators with `manage_options` can manage settings.
+
+## Required Default Location
+
+The public planner should not be considered configured until these required
+fields are set:
+
+- `default_location_label`
+- `default_location_address`
+
+Optional default location fields:
+
+- `default_location_latitude`
+- `default_location_longitude`
+- `default_location_place_id`
+
+Destination-specific values belong in settings or migration data, not plugin
+defaults.
+
+## Planner Behavior
+
+- `allowed_start_modes`: allowed starting controls. Supported values are
+  `default`, `custom`, and `current`.
+- `max_waypoints`: maximum selected places a public request may resolve.
+- `result_count`: maximum Google text-search results requested per browse
+  action.
+- `distance_unit`: `miles` or `kilometers`.
+- `map_preview_enabled`: allows future on-page Maps Embed previews.
+- `maps_handoff_enabled`: allows future outbound Google Maps links.
+
+## Google API Keys
+
+- `google_maps_embed_api_key`: browser-facing Maps Embed API key. This key can
+  appear in iframe URLs.
+- `google_places_api_key`: server-side Places API key for text search and place
+  details.
+- `google_geocoding_api_key`: optional server-side Geocoding API key. If empty,
+  the plugin uses the Places API key for geocoding.
+
+Server-side keys must not be sent to frontend runtime config.
+
+## Google API Behavior
+
+- `google_api_timeout`: request timeout, clamped from 1 to 30 seconds.
+- `google_text_search_cache_ttl`: successful text search cache TTL in seconds.
+- `google_place_details_cache_ttl`: successful place details cache TTL in
+  seconds.
+- `google_geocoding_cache_ttl`: successful geocoding cache TTL in seconds.
+
+TTL values can be set to `0` to disable that cache path.
+
+## Rate Limit And Trusted Proxies
+
+- `rate_limit_per_minute`: stored configuration for the future public endpoint
+  rate limiter.
+- `trusted_proxy_cidrs`: optional IP/CIDR list, one per line, for future
+  trusted-proxy-aware client IP resolution.
+
+Invalid trusted proxy entries are discarded during sanitization.
+
+## Sanitization
+
+Settings are sanitized in `Acodebeard\PlanYourDay\Settings\Settings`.
+
+Important behavior:
+
+- Text fields are trimmed and sanitized with WordPress text sanitizers.
+- Coordinates must be numeric and inside valid latitude/longitude ranges.
+- Google API keys and Place IDs keep only expected key characters.
+- Boolean values are normalized from checkbox-style input.
+- Numeric limits are clamped to conservative ranges.
+- Unknown start modes and distance units fall back to safe defaults.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,71 @@
+# Troubleshooting
+
+## Plugin Activation Fails: Missing Autoloader
+
+Source checkouts require Composer:
+
+```sh
+cd plugin/plan-your-day
+composer install
+```
+
+Release zips should already include `vendor/autoload.php`.
+
+## WP-CLI Cannot Connect To Database
+
+For XAMPP installs, make sure Apache and MySQL are running:
+
+```sh
+sudo /opt/lampp/lampp start
+```
+
+Use XAMPP PHP when testing the DKC install:
+
+```sh
+/opt/lampp/bin/php /usr/local/bin/wp \
+  --path=/opt/lampp/htdocs/dkc \
+  --url=http://localhost/dkc \
+  plugin status plan-your-day \
+  --allow-root
+```
+
+## WordPress Says The Site Is Not Installed
+
+The generic `/opt/lampp/htdocs/wordpress` directory may have WordPress files but
+no installed database tables. The current target test site is:
+
+```text
+/opt/lampp/htdocs/dkc
+```
+
+## Settings Page Does Not Appear In A WP-CLI Smoke Test
+
+`add_options_page()` checks capabilities. If testing menu registration through
+WP-CLI, set an administrator user first:
+
+```sh
+/opt/lampp/bin/php /usr/local/bin/wp \
+  --path=/opt/lampp/htdocs/dkc \
+  --url=http://localhost/dkc \
+  eval 'wp_set_current_user(1); do_action("admin_menu"); global $submenu; var_export($submenu["options-general.php"] ?? []);' \
+  --allow-root
+```
+
+## Composer Emits Deprecation Notices
+
+The system Composer package can emit deprecation notices on newer PHP versions.
+The command can still complete successfully. The important output is that
+autoload files were generated.
+
+## Google Results Are Unavailable
+
+Current likely causes:
+
+- Missing Places API key.
+- Missing or restricted Geocoding API key, when geocoding is needed.
+- Google Cloud APIs not enabled.
+- API key restrictions do not allow the server or browser context being used.
+- Provider request failure or invalid response.
+
+The frontend planner is not wired yet, so current Google behavior is mostly
+validated through WP-CLI or future REST/renderer work.

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -12,7 +12,15 @@ A configurable day planning plugin for WordPress.
 
 == Description ==
 
-Placeholder. Plugin scaffold only — functional features land in subsequent issues.
+Plan Your Day is a configurable day planning plugin for WordPress.
+
+Current development builds include the plugin scaffold, Settings API
+registration, admin settings screen, Google API client abstraction, Google API
+caching, and extracted planner helper services.
+
+The public planner frontend, shortcode, block wrapper, REST endpoints, visitor
+token protection, release build process, migration helper, and production QA
+are still in progress.
 
 == Installation ==
 
@@ -23,17 +31,46 @@ Release zip:
 
 Source checkout:
 
-1. Copy the `plan-your-day` directory to `/wp-content/plugins/`.
-2. Run `composer install` inside the plugin directory to generate the autoloader.
+1. Copy or symlink the `plan-your-day` directory to `/wp-content/plugins/`.
+2. Run `composer install` inside the plugin directory to generate
+   `vendor/autoload.php`.
 3. Activate the plugin through the Plugins screen in WordPress.
+4. Open Settings > Plan Your Day and configure the required default location
+   and Google API keys.
+
+== Configuration ==
+
+Settings are stored in the `plan_your_day_settings` option and managed through
+Settings > Plan Your Day.
+
+Current settings include:
+
+* Default location label, address/search phrase, latitude, longitude, and Place ID.
+* Allowed start modes, max waypoints, result count, distance unit, map preview,
+  and Google Maps handoff toggles.
+* Browser-facing Maps Embed API key.
+* Server-side Places and Geocoding API keys.
+* Google API timeout and cache TTLs.
+* Rate-limit value and trusted proxy CIDRs for future endpoint protection.
 
 == Frequently Asked Questions ==
 
 = Is this ready for production? =
 
-No. This is an initial scaffold; features are introduced through the issue tracker.
+No. The plugin is installable and the admin/settings/API foundations are in
+place, but the public planner frontend and REST endpoints are not complete.
+
+= Where is the developer documentation? =
+
+See the repository `docs/` directory for installation, architecture, settings,
+security, and troubleshooting notes.
 
 == Changelog ==
+
+= Unreleased =
+* Added Settings API registration and admin settings screen.
+* Added Google API client abstraction and transient-backed caching.
+* Added extracted planner helper services for future shortcode and REST work.
 
 = 0.1.0 =
 * Initial plugin scaffold (GH issue #20): directory structure, main plugin file, activation / deactivation hooks, uninstall routine, PSR-4 autoloading.

--- a/plugin/plan-your-day/src/Google/GoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiClient.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Google;
 
+use Acodebeard\PlanYourDay\Planner\PlaceParser;
 use Acodebeard\PlanYourDay\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -16,10 +17,12 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 
 	private Settings $settings;
 	private GoogleHttpTransportInterface $transport;
+	private PlaceParser $place_parser;
 
-	public function __construct( Settings $settings, ?GoogleHttpTransportInterface $transport = null ) {
-		$this->settings  = $settings;
-		$this->transport = $transport ?? new WordPressGoogleHttpTransport();
+	public function __construct( Settings $settings, ?GoogleHttpTransportInterface $transport = null, ?PlaceParser $place_parser = null ) {
+		$this->settings     = $settings;
+		$this->transport    = $transport ?? new WordPressGoogleHttpTransport();
+		$this->place_parser = $place_parser ?? new PlaceParser();
 	}
 
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
@@ -87,7 +90,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		$places = [];
 
 		foreach ( (array) ( $decoded['body']['places'] ?? [] ) as $place ) {
-			$parsed_place = $this->parse_place( (array) $place );
+			$parsed_place = $this->place_parser->parse_google_place( (array) $place );
 
 			if ( ! $parsed_place['is_valid'] ) {
 				continue;
@@ -106,7 +109,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	public function place_details( string $place_id ): GoogleApiResult {
-		$place_id = $this->sanitize_place_id( $place_id );
+		$place_id = PlaceParser::sanitize_place_id( $place_id );
 
 		if ( '' === $place_id ) {
 			return GoogleApiResult::failure(
@@ -148,7 +151,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 			return $decoded;
 		}
 
-		$place = $this->parse_place( (array) $decoded['body'] );
+		$place = $this->place_parser->parse_google_place( (array) $decoded['body'] );
 
 		if ( ! $place['is_valid'] ) {
 			return GoogleApiResult::failure(
@@ -271,37 +274,6 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 			'body'        => $body,
 			'status_code' => $status_code,
 		];
-	}
-
-	private function parse_place( array $place ): array {
-		$display_name = is_array( $place['displayName'] ?? null ) ? $place['displayName'] : [];
-		$location     = is_array( $place['location'] ?? null ) ? $place['location'] : [];
-		$place_id     = $this->sanitize_place_id( (string) ( $place['id'] ?? '' ) );
-		$label        = trim( sanitize_text_field( (string) ( $display_name['text'] ?? '' ) ) );
-		$address      = trim( sanitize_text_field( (string) ( $place['formattedAddress'] ?? '' ) ) );
-		$maps_uri     = $this->safe_https_url( (string) ( $place['googleMapsUri'] ?? '' ) );
-		$latitude     = isset( $location['latitude'] ) && is_numeric( $location['latitude'] ) ? (float) $location['latitude'] : null;
-		$longitude    = isset( $location['longitude'] ) && is_numeric( $location['longitude'] ) ? (float) $location['longitude'] : null;
-
-		return [
-			'id'        => $place_id,
-			'label'     => '' !== $label ? $label : $address,
-			'address'   => $address,
-			'maps_uri'  => $maps_uri,
-			'latitude'  => $latitude,
-			'longitude' => $longitude,
-			'is_valid'  => '' !== $place_id && ( '' !== $label || '' !== $address ),
-		];
-	}
-
-	private function sanitize_place_id( string $place_id ): string {
-		return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', trim( $place_id ) );
-	}
-
-	private function safe_https_url( string $url ): string {
-		$url = trim( $url );
-
-		return 1 === preg_match( '#\Ahttps://[^\s<>"\']+\z#i', $url ) ? $url : '';
 	}
 
 	private function is_valid_coordinate( ?float $coordinate, float $minimum, float $maximum ): bool {

--- a/plugin/plan-your-day/src/Planner/DistanceFormatter.php
+++ b/plugin/plan-your-day/src/Planner/DistanceFormatter.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+use Acodebeard\PlanYourDay\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class DistanceFormatter {
+	private const EARTH_RADIUS_MILES = 3958.8;
+	private const MILES_TO_KILOMETERS = 1.609344;
+
+	public function calculate_miles(
+		float $origin_latitude,
+		float $origin_longitude,
+		float $destination_latitude,
+		float $destination_longitude
+	): float {
+		$latitude_delta           = deg2rad( $destination_latitude - $origin_latitude );
+		$longitude_delta          = deg2rad( $destination_longitude - $origin_longitude );
+		$origin_latitude_rad      = deg2rad( $origin_latitude );
+		$destination_latitude_rad = deg2rad( $destination_latitude );
+		$haversine                = sin( $latitude_delta / 2 ) ** 2
+			+ cos( $origin_latitude_rad ) * cos( $destination_latitude_rad ) * sin( $longitude_delta / 2 ) ** 2;
+		$central_angle            = 2 * asin( min( 1, sqrt( $haversine ) ) );
+
+		return self::EARTH_RADIUS_MILES * $central_angle;
+	}
+
+	public function format_label( float $distance_miles, string $reference_label, string $distance_unit ): string {
+		$reference_label = trim( $reference_label );
+		$distance_unit   = Settings::DISTANCE_UNIT_KILOMETERS === $distance_unit
+			? Settings::DISTANCE_UNIT_KILOMETERS
+			: Settings::DISTANCE_UNIT_MILES;
+		$distance        = Settings::DISTANCE_UNIT_KILOMETERS === $distance_unit
+			? $distance_miles * self::MILES_TO_KILOMETERS
+			: $distance_miles;
+		$unit_label      = Settings::DISTANCE_UNIT_KILOMETERS === $distance_unit ? 'km' : 'mi';
+
+		if ( $distance < 0.1 ) {
+			if ( '' === $reference_label ) {
+				return sprintf(
+					/* translators: %s is a distance unit abbreviation, such as mi or km. */
+					__( 'Less than 0.1 %s away', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+					$unit_label
+				);
+			}
+
+			return sprintf(
+				/* translators: 1: distance unit abbreviation, 2: starting point label. */
+				__( 'Less than 0.1 %1$s from %2$s', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+				$unit_label,
+				$reference_label
+			);
+		}
+
+		$rounded_distance = $distance >= 10
+			? number_format_i18n( $distance, 0 )
+			: number_format_i18n( $distance, 1 );
+
+		if ( '' === $reference_label ) {
+			return sprintf(
+				/* translators: 1: rounded distance, 2: distance unit abbreviation. */
+				__( 'Approx. %1$s %2$s away', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+				$rounded_distance,
+				$unit_label
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: rounded distance, 2: distance unit abbreviation, 3: starting point label. */
+			__( 'Approx. %1$s %2$s from %3$s', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+			$rounded_distance,
+			$unit_label,
+			$reference_label
+		);
+	}
+}

--- a/plugin/plan-your-day/src/Planner/MapUrlBuilder.php
+++ b/plugin/plan-your-day/src/Planner/MapUrlBuilder.php
@@ -1,0 +1,177 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+defined( 'ABSPATH' ) || exit;
+
+final class MapUrlBuilder {
+	public function build_category_query( array $category, string $search_area, bool $use_current_location = false ): string {
+		$text_query = trim( sanitize_text_field( (string) ( $category['text_query'] ?? $category['label'] ?? '' ) ) );
+
+		if ( '' === $text_query ) {
+			return '';
+		}
+
+		if ( $use_current_location ) {
+			return $text_query . ' near me';
+		}
+
+		$search_area = trim( sanitize_text_field( $search_area ) );
+
+		if ( '' === $search_area ) {
+			return $text_query;
+		}
+
+		return $text_query . ' near ' . $search_area;
+	}
+
+	public function build_state_url( string $action_url, array $params, string $section_id ): string {
+		$url = esc_url_raw( $action_url );
+
+		if ( [] !== $params ) {
+			$url = add_query_arg( $params, $url );
+		}
+
+		return $url . '#' . sanitize_key( $section_id );
+	}
+
+	public function build_embed_search_url( string $embed_api_key, string $query ): string {
+		$embed_api_key = trim( $embed_api_key );
+		$query         = trim( $query );
+
+		if ( '' === $embed_api_key || '' === $query ) {
+			return '';
+		}
+
+		return add_query_arg(
+			[
+				'key' => $embed_api_key,
+				'q'   => $query,
+			],
+			'https://www.google.com/maps/embed/v1/search'
+		);
+	}
+
+	public function build_search_handoff_url( string $query ): string {
+		$query = trim( $query );
+
+		if ( '' === $query ) {
+			return '';
+		}
+
+		return add_query_arg(
+			[
+				'api'   => '1',
+				'query' => $query,
+			],
+			'https://www.google.com/maps/search/'
+		);
+	}
+
+	public function build_embed_directions_url( string $embed_api_key, string $origin, array $waypoints ): string {
+		$embed_api_key = trim( $embed_api_key );
+		$origin        = trim( $origin );
+		$waypoints     = $this->valid_waypoints( $waypoints );
+
+		if ( '' === $embed_api_key || '' === $origin || [] === $waypoints ) {
+			return '';
+		}
+
+		$destination = $waypoints[ count( $waypoints ) - 1 ];
+		$params      = [
+			'key'         => $embed_api_key,
+			'origin'      => $origin,
+			'destination' => 'place_id:' . $destination['id'],
+			'mode'        => 'walking',
+		];
+
+		$intermediates = count( $waypoints ) > 1 ? array_slice( $waypoints, 0, -1 ) : [];
+
+		if ( [] !== $intermediates ) {
+			$params['waypoints'] = implode(
+				'|',
+				array_map(
+					static function ( array $waypoint ): string {
+						return 'place_id:' . $waypoint['id'];
+					},
+					$intermediates
+				)
+			);
+		}
+
+		return add_query_arg( $params, 'https://www.google.com/maps/embed/v1/directions' );
+	}
+
+	public function build_directions_handoff_url( ?string $origin, array $waypoints ): string {
+		$waypoints = $this->valid_waypoints( $waypoints );
+
+		if ( [] === $waypoints ) {
+			return '';
+		}
+
+		$destination = $waypoints[ count( $waypoints ) - 1 ];
+		$params      = [
+			'api'                  => '1',
+			'destination'          => '' !== $destination['address'] ? $destination['address'] : $destination['label'],
+			'destination_place_id' => $destination['id'],
+			'travelmode'           => 'walking',
+		];
+		$origin      = null === $origin ? '' : trim( $origin );
+
+		if ( '' !== $origin ) {
+			$params['origin'] = $origin;
+		}
+
+		$intermediates = count( $waypoints ) > 1 ? array_slice( $waypoints, 0, -1 ) : [];
+
+		if ( [] !== $intermediates ) {
+			$params['waypoints'] = implode(
+				'|',
+				array_map(
+					static function ( array $waypoint ): string {
+						return '' !== $waypoint['address'] ? $waypoint['address'] : $waypoint['label'];
+					},
+					$intermediates
+				)
+			);
+			$params['waypoint_place_ids'] = implode(
+				'|',
+				array_map(
+					static function ( array $waypoint ): string {
+						return $waypoint['id'];
+					},
+					$intermediates
+				)
+			);
+		}
+
+		return add_query_arg( $params, 'https://www.google.com/maps/dir/' );
+	}
+
+	private function valid_waypoints( array $waypoints ): array {
+		$valid_waypoints = [];
+
+		foreach ( $waypoints as $waypoint ) {
+			if ( ! is_array( $waypoint ) ) {
+				continue;
+			}
+
+			$place_id = PlaceParser::sanitize_place_id( (string) ( $waypoint['id'] ?? '' ) );
+			$label    = trim( sanitize_text_field( (string) ( $waypoint['label'] ?? '' ) ) );
+			$address  = trim( sanitize_text_field( (string) ( $waypoint['address'] ?? '' ) ) );
+
+			if ( '' === $place_id || ( '' === $label && '' === $address ) ) {
+				continue;
+			}
+
+			$valid_waypoints[] = [
+				'id'      => $place_id,
+				'label'   => '' !== $label ? $label : $address,
+				'address' => $address,
+			];
+		}
+
+		return $valid_waypoints;
+	}
+}

--- a/plugin/plan-your-day/src/Planner/PlaceParser.php
+++ b/plugin/plan-your-day/src/Planner/PlaceParser.php
@@ -1,0 +1,52 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PlaceParser {
+	/**
+	 * Shape a Google place response into the planner's internal place array.
+	 *
+	 * @return array{
+	 *     id: string,
+	 *     label: string,
+	 *     address: string,
+	 *     maps_uri: string,
+	 *     latitude: float|null,
+	 *     longitude: float|null,
+	 *     is_valid: bool
+	 * }
+	 */
+	public function parse_google_place( array $place ): array {
+		$display_name = is_array( $place['displayName'] ?? null ) ? $place['displayName'] : [];
+		$location     = is_array( $place['location'] ?? null ) ? $place['location'] : [];
+		$place_id     = self::sanitize_place_id( (string) ( $place['id'] ?? '' ) );
+		$label        = trim( sanitize_text_field( (string) ( $display_name['text'] ?? '' ) ) );
+		$address      = trim( sanitize_text_field( (string) ( $place['formattedAddress'] ?? '' ) ) );
+		$maps_uri     = self::safe_https_url( (string) ( $place['googleMapsUri'] ?? '' ) );
+		$latitude     = isset( $location['latitude'] ) && is_numeric( $location['latitude'] ) ? (float) $location['latitude'] : null;
+		$longitude    = isset( $location['longitude'] ) && is_numeric( $location['longitude'] ) ? (float) $location['longitude'] : null;
+
+		return [
+			'id'        => $place_id,
+			'label'     => '' !== $label ? $label : $address,
+			'address'   => $address,
+			'maps_uri'  => $maps_uri,
+			'latitude'  => $latitude,
+			'longitude' => $longitude,
+			'is_valid'  => '' !== $place_id && ( '' !== $label || '' !== $address ),
+		];
+	}
+
+	public static function sanitize_place_id( string $place_id ): string {
+		return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', trim( $place_id ) );
+	}
+
+	public static function safe_https_url( string $url ): string {
+		$url = trim( $url );
+
+		return 1 === preg_match( '#\Ahttps://[^\s<>"\']+\z#i', $url ) ? $url : '';
+	}
+}

--- a/plugin/plan-your-day/src/Planner/RequestStateParser.php
+++ b/plugin/plan-your-day/src/Planner/RequestStateParser.php
@@ -1,0 +1,54 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+use Acodebeard\PlanYourDay\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class RequestStateParser {
+	private WaypointList $waypoint_list;
+
+	public function __construct( WaypointList $waypoint_list ) {
+		$this->waypoint_list = $waypoint_list;
+	}
+
+	public function parse( array $request ): array {
+		$selected_waypoint_ids = isset( $request['waypoints'] ) ? wp_unslash( (array) $request['waypoints'] ) : [];
+		$selected_waypoint_ids = $this->waypoint_list->normalize_ids( $selected_waypoint_ids );
+
+		if ( isset( $request['clear_trip'] ) ) {
+			$selected_waypoint_ids = [];
+		} elseif ( isset( $request['remove_waypoint'] ) ) {
+			$remove_waypoint_id = PlaceParser::sanitize_place_id( wp_unslash( (string) $request['remove_waypoint'] ) );
+
+			if ( '' !== $remove_waypoint_id ) {
+				$selected_waypoint_ids = array_values(
+					array_filter(
+						$selected_waypoint_ids,
+						static function ( string $waypoint_id ) use ( $remove_waypoint_id ): bool {
+							return $waypoint_id !== $remove_waypoint_id;
+						}
+					)
+				);
+			}
+		} elseif ( isset( $request['move_waypoint'] ) ) {
+			$move_waypoint_request = sanitize_text_field( wp_unslash( (string) $request['move_waypoint'] ) );
+			$move_waypoint_parts   = explode( ':', $move_waypoint_request, 2 );
+			$move_waypoint_id      = PlaceParser::sanitize_place_id( $move_waypoint_parts[0] ?? '' );
+			$move_direction        = sanitize_key( $move_waypoint_parts[1] ?? '' );
+
+			if ( '' !== $move_waypoint_id && in_array( $move_direction, [ 'up', 'down' ], true ) ) {
+				$selected_waypoint_ids = $this->waypoint_list->move_id( $selected_waypoint_ids, $move_waypoint_id, $move_direction );
+			}
+		}
+
+		return [
+			'category_key'          => isset( $request['category'] ) ? sanitize_key( wp_unslash( (string) $request['category'] ) ) : '',
+			'selected_waypoint_ids' => $selected_waypoint_ids,
+			'start_mode'            => isset( $request['start_mode'] ) ? sanitize_key( wp_unslash( (string) $request['start_mode'] ) ) : Settings::START_MODE_DEFAULT,
+			'custom_start'          => isset( $request['custom_start'] ) ? trim( sanitize_text_field( wp_unslash( (string) $request['custom_start'] ) ) ) : '',
+		];
+	}
+}

--- a/plugin/plan-your-day/src/Planner/StartContextResolver.php
+++ b/plugin/plan-your-day/src/Planner/StartContextResolver.php
@@ -1,0 +1,91 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+use Acodebeard\PlanYourDay\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class StartContextResolver {
+	private Settings $settings;
+
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * @return array{
+	 *     search_area: string,
+	 *     preview_start_label: string,
+	 *     handoff_start_label: string,
+	 *     handoff_summary: string,
+	 *     use_current_handoff: bool,
+	 *     directions_origin: string|null,
+	 *     start_note_text: string,
+	 *     messages: array<int, array{type: string, text: string}>
+	 * }
+	 */
+	public function resolve( string $start_mode, string $custom_start ): array {
+		$allowed_modes          = $this->settings->get_allowed_start_modes();
+		$default_location_label = $this->settings->get_default_location_label();
+		$default_address        = $this->settings->get_default_location_address();
+		$custom_start           = trim( sanitize_text_field( $custom_start ) );
+		$start_mode             = sanitize_key( $start_mode );
+
+		if ( ! in_array( $start_mode, $allowed_modes, true ) ) {
+			$start_mode = Settings::START_MODE_DEFAULT;
+		}
+
+		if ( '' === $default_location_label ) {
+			$default_location_label = __( 'Default location', PLAN_YOUR_DAY_TEXT_DOMAIN );
+		}
+
+		$preview_start_label = $default_location_label;
+		$handoff_start_label = $default_location_label;
+		$handoff_summary     = $default_location_label;
+		$search_area         = $default_address;
+		$directions_origin   = $default_address;
+		$messages            = [];
+		$use_current_handoff = false;
+		$start_note_text     = __( 'The on-page results, preview, and Google Maps handoff use the configured default starting point.', PLAN_YOUR_DAY_TEXT_DOMAIN );
+
+		if ( Settings::START_MODE_CURRENT === $start_mode ) {
+			$handoff_start_label = __( 'Current location', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$handoff_summary     = __( 'your current location', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$directions_origin   = null;
+			$use_current_handoff = true;
+			$start_note_text     = __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$messages[]          = [
+				'type' => 'note',
+				'text' => __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+			];
+		} elseif ( Settings::START_MODE_CUSTOM === $start_mode && '' !== $custom_start ) {
+			$search_area         = $custom_start;
+			$preview_start_label = $custom_start;
+			$handoff_start_label = $custom_start;
+			$handoff_summary     = $custom_start;
+			$directions_origin   = $custom_start;
+			$start_note_text     = __( 'The on-page results, preview, and Google Maps handoff all use the custom starting point.', PLAN_YOUR_DAY_TEXT_DOMAIN );
+		} elseif ( Settings::START_MODE_CUSTOM === $start_mode ) {
+			$handoff_start_label = __( 'Default location fallback', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$handoff_summary     = __( 'the default location until a custom starting point is provided', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$start_note_text     = __( 'Add a custom address to replace the default fallback for search results, the route preview, and the Google Maps handoff.', PLAN_YOUR_DAY_TEXT_DOMAIN );
+			$messages[]          = [
+				'type' => 'warning',
+				'text' => __( 'Add a custom address to replace the default fallback before finalizing the trip start.', PLAN_YOUR_DAY_TEXT_DOMAIN ),
+			];
+		}
+
+		return [
+			'search_area'         => $search_area,
+			'preview_start_label' => $preview_start_label,
+			'handoff_start_label' => $handoff_start_label,
+			'handoff_summary'     => $handoff_summary,
+			'use_current_handoff' => $use_current_handoff,
+			'directions_origin'   => $directions_origin,
+			'start_note_text'     => $start_note_text,
+			'messages'            => $messages,
+		];
+	}
+}

--- a/plugin/plan-your-day/src/Planner/WaypointList.php
+++ b/plugin/plan-your-day/src/Planner/WaypointList.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Planner;
+
+use Acodebeard\PlanYourDay\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class WaypointList {
+	private Settings $settings;
+
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	public function normalize_ids( array $waypoint_ids ): array {
+		$normalized_waypoint_ids = [];
+		$max_waypoints           = max( 1, $this->settings->get_max_waypoints() );
+
+		foreach ( $waypoint_ids as $waypoint_id ) {
+			$waypoint_id = PlaceParser::sanitize_place_id( (string) $waypoint_id );
+
+			if ( '' === $waypoint_id || in_array( $waypoint_id, $normalized_waypoint_ids, true ) ) {
+				continue;
+			}
+
+			$normalized_waypoint_ids[] = $waypoint_id;
+
+			if ( count( $normalized_waypoint_ids ) >= $max_waypoints ) {
+				break;
+			}
+		}
+
+		return $normalized_waypoint_ids;
+	}
+
+	public function move_id( array $waypoint_ids, string $place_id, string $direction ): array {
+		$waypoint_ids  = $this->normalize_ids( $waypoint_ids );
+		$place_id      = PlaceParser::sanitize_place_id( $place_id );
+		$current_index = array_search( $place_id, $waypoint_ids, true );
+
+		if ( false === $current_index ) {
+			return $waypoint_ids;
+		}
+
+		$next_index = 'up' === $direction ? $current_index - 1 : $current_index + 1;
+
+		if ( $next_index < 0 || $next_index >= count( $waypoint_ids ) ) {
+			return $waypoint_ids;
+		}
+
+		$reordered_waypoint_ids = $waypoint_ids;
+		$moved_waypoint_id      = $reordered_waypoint_ids[ $current_index ];
+
+		array_splice( $reordered_waypoint_ids, $current_index, 1 );
+		array_splice( $reordered_waypoint_ids, $next_index, 0, [ $moved_waypoint_id ] );
+
+		return array_values( $reordered_waypoint_ids );
+	}
+}

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -8,6 +8,13 @@ use Acodebeard\PlanYourDay\Google\CachedGoogleApiClient;
 use Acodebeard\PlanYourDay\Google\GoogleApiClient;
 use Acodebeard\PlanYourDay\Google\GoogleApiCache;
 use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+use Acodebeard\PlanYourDay\Planner\DistanceFormatter;
+use Acodebeard\PlanYourDay\Planner\MapUrlBuilder;
+use Acodebeard\PlanYourDay\Planner\PlaceParser;
+use Acodebeard\PlanYourDay\Planner\RequestStateParser;
+use Acodebeard\PlanYourDay\Planner\StartContextResolver;
+use Acodebeard\PlanYourDay\Planner\WaypointList;
+use Acodebeard\PlanYourDay\Security\RequestOriginValidator;
 use Acodebeard\PlanYourDay\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +25,13 @@ final class Plugin {
 	private SettingsPage $settings_page;
 	private GoogleApiCache $google_api_cache;
 	private ?GoogleApiClientInterface $google_api_client = null;
+	private PlaceParser $place_parser;
+	private WaypointList $waypoint_list;
+	private RequestStateParser $request_state_parser;
+	private StartContextResolver $start_context_resolver;
+	private MapUrlBuilder $map_url_builder;
+	private DistanceFormatter $distance_formatter;
+	private RequestOriginValidator $request_origin_validator;
 
 	public static function instance(): Plugin {
 		if ( null === self::$instance ) {
@@ -30,6 +44,13 @@ final class Plugin {
 		$this->settings         = new Settings();
 		$this->google_api_cache = new GoogleApiCache();
 		$this->settings_page    = new SettingsPage( $this->settings, $this->google_api_cache );
+		$this->place_parser     = new PlaceParser();
+		$this->waypoint_list    = new WaypointList( $this->settings );
+		$this->request_state_parser     = new RequestStateParser( $this->waypoint_list );
+		$this->start_context_resolver   = new StartContextResolver( $this->settings );
+		$this->map_url_builder          = new MapUrlBuilder();
+		$this->distance_formatter       = new DistanceFormatter();
+		$this->request_origin_validator = new RequestOriginValidator();
 	}
 
 	public function init(): void {
@@ -55,7 +76,7 @@ final class Plugin {
 	public function google_api_client(): GoogleApiClientInterface {
 		if ( null === $this->google_api_client ) {
 			$this->google_api_client = new CachedGoogleApiClient(
-				new GoogleApiClient( $this->settings ),
+				new GoogleApiClient( $this->settings, null, $this->place_parser ),
 				$this->settings,
 				$this->google_api_cache
 			);
@@ -66,5 +87,33 @@ final class Plugin {
 
 	public function google_api_cache(): GoogleApiCache {
 		return $this->google_api_cache;
+	}
+
+	public function place_parser(): PlaceParser {
+		return $this->place_parser;
+	}
+
+	public function waypoint_list(): WaypointList {
+		return $this->waypoint_list;
+	}
+
+	public function request_state_parser(): RequestStateParser {
+		return $this->request_state_parser;
+	}
+
+	public function start_context_resolver(): StartContextResolver {
+		return $this->start_context_resolver;
+	}
+
+	public function map_url_builder(): MapUrlBuilder {
+		return $this->map_url_builder;
+	}
+
+	public function distance_formatter(): DistanceFormatter {
+		return $this->distance_formatter;
+	}
+
+	public function request_origin_validator(): RequestOriginValidator {
+		return $this->request_origin_validator;
 	}
 }

--- a/plugin/plan-your-day/src/Security/RequestOriginValidator.php
+++ b/plugin/plan-your-day/src/Security/RequestOriginValidator.php
@@ -1,0 +1,55 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Security;
+
+defined( 'ABSPATH' ) || exit;
+
+final class RequestOriginValidator {
+	public function is_same_site_request( array $server ): bool {
+		$expected_host_header = (string) ( $server['HTTP_HOST'] ?? '' );
+		$expected_host        = wp_parse_url( 'http://' . $expected_host_header, PHP_URL_HOST );
+		$expected_port        = wp_parse_url( 'http://' . $expected_host_header, PHP_URL_PORT );
+
+		if ( ! is_string( $expected_host ) || '' === $expected_host ) {
+			return true;
+		}
+
+		$fetch_site = strtolower( trim( (string) ( $server['HTTP_SEC_FETCH_SITE'] ?? '' ) ) );
+
+		if ( '' !== $fetch_site && ! in_array( $fetch_site, [ 'same-origin', 'none' ], true ) ) {
+			$fetch_mode = strtolower( trim( (string) ( $server['HTTP_SEC_FETCH_MODE'] ?? '' ) ) );
+			$fetch_dest = strtolower( trim( (string) ( $server['HTTP_SEC_FETCH_DEST'] ?? '' ) ) );
+			$fetch_user = trim( (string) ( $server['HTTP_SEC_FETCH_USER'] ?? '' ) );
+
+			if (
+				'navigate' !== $fetch_mode ||
+				'document' !== $fetch_dest ||
+				'?1' !== $fetch_user
+			) {
+				return false;
+			}
+		}
+
+		foreach ( [ 'HTTP_ORIGIN', 'HTTP_REFERER' ] as $header ) {
+			$value = (string) ( $server[ $header ] ?? '' );
+
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$candidate_host = wp_parse_url( $value, PHP_URL_HOST );
+			$candidate_port = wp_parse_url( $value, PHP_URL_PORT );
+
+			if (
+				! is_string( $candidate_host ) ||
+				0 !== strcasecmp( $candidate_host, $expected_host ) ||
+				( null !== $expected_port && $candidate_port !== $expected_port )
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary

Starts issue #22 by extracting standalone planner helper logic into plugin-native services without changing the standalone runtime or wiring frontend/REST yet.

## Changes

- Add planner services for place parsing, waypoint ID normalization/reordering, distance labels, map URL construction, request-state parsing, and start context resolution.
- Add a request origin validator for the same-site request helper.
- Update the Google API client to use the shared `PlaceParser`, so place parsing is isolated in live plugin code.
- Expose the new services from the plugin container for later shortcode and REST work.

## Validation

- Ran PHP lint across plugin PHP files.
- Ran `git diff --check`.
- Verified the local DKC WordPress install still reports `plan-your-day` active.
- Verified admin settings page registration through WP-CLI as admin user.
- Verified new services autoload through WP-CLI.
- Verified `GoogleApiClient::text_search()` parses fake transport results through the new parser.
- Confirmed no destination-specific strings were added to plugin source.

## Notes

This does not close #22. Render extraction from standalone `index.php` remains for a follow-up slice.