### PR TITLE
[codex] Bound public trip waypoint resolution

### DIFF
--- a/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
@@ -36,7 +36,7 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		);
 	}
 
-	public function place_details( string $place_id ): GoogleApiResult {
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
 		$cache_key = $this->cache->build_key(
 			'place_details',
 			[
@@ -48,7 +48,7 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		return $this->remember(
 			$cache_key,
 			$this->settings->get_google_place_details_cache_ttl(),
-			fn (): GoogleApiResult => $this->client->place_details( $place_id )
+			fn (): GoogleApiResult => $this->client->place_details( $place_id, $timeout )
 		);
 	}
 

--- a/plugin/plan-your-day/src/Google/GoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiClient.php
@@ -119,7 +119,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		);
 	}
 
-	public function place_details( string $place_id ): GoogleApiResult {
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
 		$place_id = PlaceParser::sanitize_place_id( $place_id );
 
 		if ( '' === $place_id ) {
@@ -152,7 +152,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		$response = $this->transport->get(
 			self::PLACE_DETAILS_ENDPOINT . rawurlencode( $place_id ),
 			[
-				'timeout' => $this->settings->get_google_api_timeout(),
+				'timeout' => $this->resolve_timeout( $timeout ),
 				'headers' => [
 					'X-Goog-Api-Key'   => $api_key,
 					'X-Goog-FieldMask' => self::PLACE_DETAILS_FIELD_MASK,
@@ -188,6 +188,16 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 			],
 			$decoded['status_code']
 		);
+	}
+
+	private function resolve_timeout( ?int $timeout_override = null ): int {
+		$timeout = $this->settings->get_google_api_timeout();
+
+		if ( null === $timeout_override || $timeout_override < 1 ) {
+			return $timeout;
+		}
+
+		return min( $timeout, $timeout_override );
 	}
 
 	public function geocode( string $address ): GoogleApiResult {

--- a/plugin/plan-your-day/src/Google/GoogleApiClientInterface.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiClientInterface.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 interface GoogleApiClientInterface {
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult;
 
-	public function place_details( string $place_id ): GoogleApiResult;
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult;
 
 	public function geocode( string $address ): GoogleApiResult;
 }

--- a/plugin/plan-your-day/src/Planner/PlannerStateBuilder.php
+++ b/plugin/plan-your-day/src/Planner/PlannerStateBuilder.php
@@ -126,15 +126,18 @@ final class PlannerStateBuilder {
 		}
 
 		if ( $include_trip_waypoints && [] !== $selected_waypoint_ids ) {
-			$trip_waypoint_response = $this->get_trip_waypoints( $selected_waypoint_ids );
+			$trip_waypoint_response = $this->get_trip_waypoints( $selected_waypoint_ids, $options );
 			$trip_waypoints         = $trip_waypoint_response['waypoints'];
 			$messages               = array_merge( $messages, $trip_waypoint_response['messages'] );
-			$selected_waypoint_ids  = array_map(
-				static function ( array $waypoint ): string {
-					return (string) $waypoint['id'];
-				},
-				$trip_waypoints
-			);
+
+			if ( empty( $trip_waypoint_response['is_partial'] ) ) {
+				$selected_waypoint_ids = array_map(
+					static function ( array $waypoint ): string {
+						return (string) $waypoint['id'];
+					},
+					$trip_waypoints
+				);
+			}
 		}
 
 		$has_category         = '' !== $category_key;
@@ -278,14 +281,38 @@ final class PlannerStateBuilder {
 		}
 	}
 
-	private function get_trip_waypoints( array $waypoint_ids ): array {
-		$waypoints = [];
-		$messages  = [];
+	private function get_trip_waypoints( array $waypoint_ids, array $options = [] ): array {
+		$waypoints             = [];
+		$messages              = [];
+		$is_partial            = false;
+		$deadline_at           = $this->resolve_trip_waypoint_deadline_at( $options );
+		$place_details_timeout = $this->normalize_trip_waypoint_timeout( $options['trip_waypoint_place_details_timeout'] ?? null );
+		$max_failures          = $this->normalize_trip_waypoint_limit( $options['trip_waypoint_max_failures'] ?? null );
+		$failure_count         = 0;
 
 		foreach ( $waypoint_ids as $waypoint_id ) {
-			$detail_response = $this->google_api_client->place_details( $waypoint_id );
+			$request_timeout = $this->resolve_trip_waypoint_request_timeout( $place_details_timeout, $deadline_at );
+
+			if ( null === $request_timeout ) {
+				$is_partial = true;
+				$messages[] = [
+					'type' => 'warning',
+					'text' => __( 'The trip preview stopped loading more places before the request timed out. Try again or remove a few stops.', 'plan-your-day' ),
+				];
+				DebugLogger::log(
+					'planner.trip_waypoints.deadline_reached',
+					[
+						'requested_ids' => $waypoint_ids,
+						'loaded_count'  => count( $waypoints ),
+					]
+				);
+				break;
+			}
+
+			$detail_response = $this->google_api_client->place_details( $waypoint_id, $request_timeout );
 
 			if ( ! $detail_response->is_success() || empty( $detail_response->data()['place'] ) ) {
+				++$failure_count;
 				DebugLogger::log(
 					'planner.trip_waypoint.skipped',
 					[
@@ -301,6 +328,25 @@ final class PlannerStateBuilder {
 					'type' => 'warning',
 					'text' => __( 'One selected place could not be loaded from Google and was skipped.', 'plan-your-day' ),
 				];
+
+				if ( null !== $max_failures && $failure_count >= $max_failures ) {
+					$is_partial = true;
+					$messages[] = [
+						'type' => 'warning',
+						'text' => __( 'The trip preview stopped loading more places after repeated Google place errors. Try again later or remove any invalid stops.', 'plan-your-day' ),
+					];
+					DebugLogger::log(
+						'planner.trip_waypoints.failure_limit_reached',
+						[
+							'requested_ids' => $waypoint_ids,
+							'loaded_count'  => count( $waypoints ),
+							'failure_count' => $failure_count,
+							'max_failures'  => $max_failures,
+						]
+					);
+					break;
+				}
+
 				continue;
 			}
 
@@ -322,9 +368,60 @@ final class PlannerStateBuilder {
 		);
 
 		return [
-			'waypoints' => $waypoints,
-			'messages'  => $messages,
+			'waypoints'   => $waypoints,
+			'messages'    => $messages,
+			'is_partial'  => $is_partial,
 		];
+	}
+
+	private function resolve_trip_waypoint_deadline_at( array $options ): ?float {
+		if ( isset( $options['trip_waypoint_deadline_at'] ) && is_numeric( $options['trip_waypoint_deadline_at'] ) ) {
+			return (float) $options['trip_waypoint_deadline_at'];
+		}
+
+		if ( ! isset( $options['trip_waypoint_deadline_seconds'] ) || ! is_numeric( $options['trip_waypoint_deadline_seconds'] ) ) {
+			return null;
+		}
+
+		$deadline_seconds = (float) $options['trip_waypoint_deadline_seconds'];
+
+		if ( $deadline_seconds <= 0 ) {
+			return null;
+		}
+
+		return microtime( true ) + $deadline_seconds;
+	}
+
+	private function resolve_trip_waypoint_request_timeout( ?int $place_details_timeout, ?float $deadline_at ): ?int {
+		$request_timeout = $place_details_timeout ?? $this->settings->get_google_api_timeout();
+
+		if ( null === $deadline_at ) {
+			return $request_timeout;
+		}
+
+		$remaining_seconds = $deadline_at - microtime( true );
+
+		if ( $remaining_seconds <= 0 ) {
+			return null;
+		}
+
+		return max( 1, min( $request_timeout, (int) ceil( $remaining_seconds ) ) );
+	}
+
+	private function normalize_trip_waypoint_timeout( mixed $timeout ): ?int {
+		if ( ! is_numeric( $timeout ) ) {
+			return null;
+		}
+
+		return max( 1, min( $this->settings->get_google_api_timeout(), absint( $timeout ) ) );
+	}
+
+	private function normalize_trip_waypoint_limit( mixed $limit ): ?int {
+		if ( ! is_numeric( $limit ) ) {
+			return null;
+		}
+
+		return max( 1, absint( $limit ) );
 	}
 
 	private function build_trip_route_state( array $trip_waypoints, array $search_context ): array {

--- a/plugin/plan-your-day/src/Rest/PlannerRoutes.php
+++ b/plugin/plan-your-day/src/Rest/PlannerRoutes.php
@@ -19,6 +19,9 @@ defined( 'ABSPATH' ) || exit;
 
 final class PlannerRoutes {
 	public const REST_NAMESPACE = 'plan-your-day/v1';
+	private const PUBLIC_TRIP_WAYPOINT_DEADLINE_SECONDS = 12;
+	private const PUBLIC_TRIP_WAYPOINT_PLACE_DETAILS_TIMEOUT = 5;
+	private const PUBLIC_TRIP_WAYPOINT_MAX_FAILURES = 3;
 
 	private RequestStateParser $request_state_parser;
 	private PlannerStateBuilder $planner_state_builder;
@@ -82,10 +85,7 @@ final class PlannerRoutes {
 
 		$planner_state = $this->planner_state_builder->build(
 			$this->request_state_parser->parse( $this->request_params_from_request( $request ) ),
-			[
-				'include_results'        => true,
-				'include_trip_waypoints' => true,
-			]
+			$this->public_trip_waypoint_options( true )
 		);
 		DebugLogger::log(
 			'rest.browse.response',
@@ -122,10 +122,7 @@ final class PlannerRoutes {
 
 		$planner_state = $this->planner_state_builder->build(
 			$this->request_state_parser->parse( $this->request_params_from_request( $request ) ),
-			[
-				'include_results'        => false,
-				'include_trip_waypoints' => true,
-			]
+			$this->public_trip_waypoint_options( false )
 		);
 		DebugLogger::log(
 			'rest.route.response',
@@ -208,6 +205,16 @@ final class PlannerRoutes {
 		}
 
 		return $rate_limit;
+	}
+
+	private function public_trip_waypoint_options( bool $include_results ): array {
+		return [
+			'include_results'                    => $include_results,
+			'include_trip_waypoints'             => true,
+			'trip_waypoint_deadline_seconds'     => self::PUBLIC_TRIP_WAYPOINT_DEADLINE_SECONDS,
+			'trip_waypoint_place_details_timeout' => self::PUBLIC_TRIP_WAYPOINT_PLACE_DETAILS_TIMEOUT,
+			'trip_waypoint_max_failures'         => self::PUBLIC_TRIP_WAYPOINT_MAX_FAILURES,
+		];
 	}
 
 	private function route_args(): array {

--- a/plugin/plan-your-day/tests/GoogleApiClientTest.php
+++ b/plugin/plan-your-day/tests/GoogleApiClientTest.php
@@ -1,0 +1,77 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Google\GoogleApiClient;
+use Acodebeard\PlanYourDay\Google\GoogleHttpTransportInterface;
+use Acodebeard\PlanYourDay\Planner\PlaceParser;
+use Acodebeard\PlanYourDay\Settings\Settings;
+use PHPUnit\Framework\TestCase;
+
+final class GoogleApiClientTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ] = array_merge(
+			Settings::defaults(),
+			[
+				'google_places_api_key' => 'places-key',
+				'google_api_timeout'    => 15,
+			]
+		);
+	}
+
+	public function test_place_details_uses_timeout_override_when_it_is_lower_than_configured_timeout(): void {
+		$transport = new RecordingGoogleHttpTransport();
+		$client    = new GoogleApiClient( new Settings(), $transport, new PlaceParser() );
+
+		$result = $client->place_details( 'place-1', 4 );
+
+		self::assertTrue( $result->is_success() );
+		self::assertSame( 4, $transport->last_get_args['timeout'] ?? null );
+	}
+
+	public function test_place_details_does_not_exceed_the_configured_timeout(): void {
+		$transport = new RecordingGoogleHttpTransport();
+		$client    = new GoogleApiClient( new Settings(), $transport, new PlaceParser() );
+
+		$result = $client->place_details( 'place-1', 25 );
+
+		self::assertTrue( $result->is_success() );
+		self::assertSame( 15, $transport->last_get_args['timeout'] ?? null );
+	}
+}
+
+final class RecordingGoogleHttpTransport implements GoogleHttpTransportInterface {
+	public array $last_get_args = [];
+
+	public function get( string $url, array $args = [] ) {
+		$this->last_get_args = $args;
+
+		return [
+			'response' => [
+				'code' => 200,
+			],
+			'body'     => wp_json_encode(
+				[
+					'id'               => 'place-1',
+					'displayName'      => [
+						'text' => 'Test Place',
+					],
+					'formattedAddress' => '123 Test St',
+					'googleMapsUri'    => 'https://maps.google.com/?q=place-1',
+				]
+			),
+		];
+	}
+
+	public function post( string $url, array $args = [] ) {
+		return [
+			'response' => [
+				'code' => 200,
+			],
+			'body'     => '{}',
+		];
+	}
+}

--- a/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
+++ b/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
@@ -1,0 +1,201 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+use Acodebeard\PlanYourDay\Google\GoogleApiResult;
+use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+use Acodebeard\PlanYourDay\Planner\DistanceFormatter;
+use Acodebeard\PlanYourDay\Planner\MapUrlBuilder;
+use Acodebeard\PlanYourDay\Planner\PlannerStateBuilder;
+use Acodebeard\PlanYourDay\Planner\StartContextResolver;
+use Acodebeard\PlanYourDay\Planner\WaypointList;
+use Acodebeard\PlanYourDay\Security\RequestOriginValidator;
+use Acodebeard\PlanYourDay\Settings\Settings;
+use PHPUnit\Framework\TestCase;
+
+final class PlannerStateBuilderTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ] = array_merge(
+			Settings::defaults(),
+			[
+				'default_location_label'   => 'Downtown',
+				'default_location_address' => '123 Main St',
+				'map_preview_enabled'      => false,
+				'maps_handoff_enabled'     => false,
+				'google_api_timeout'       => 15,
+			]
+		);
+	}
+
+	public function test_build_uses_shorter_place_details_timeout_for_bounded_trip_resolution(): void {
+		$google_api_client = new FakePlannerGoogleApiClient(
+			[
+				'place-a' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-a', 'Alpha' ),
+					]
+				),
+				'place-b' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-b', 'Beta' ),
+					]
+				),
+			]
+		);
+		$builder           = $this->planner_state_builder( $google_api_client );
+
+		$state = $builder->build(
+			[
+				'selected_waypoint_ids' => [ 'place-a', 'place-b' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'                    => false,
+				'include_trip_waypoints'             => true,
+				'trip_waypoint_deadline_at'          => microtime( true ) + 60,
+				'trip_waypoint_place_details_timeout' => 4,
+			]
+		);
+
+		self::assertSame( [ 4, 4 ], $google_api_client->timeouts );
+		self::assertCount( 2, $state['trip_waypoints'] );
+	}
+
+	public function test_build_stops_loading_trip_waypoints_after_deadline(): void {
+		$google_api_client = new FakePlannerGoogleApiClient(
+			[
+				'place-a' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-a', 'Alpha' ),
+					]
+				),
+			]
+		);
+		$builder           = $this->planner_state_builder( $google_api_client );
+
+		$state = $builder->build(
+			[
+				'selected_waypoint_ids' => [ 'place-a', 'place-b' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'        => false,
+				'include_trip_waypoints' => true,
+				'trip_waypoint_deadline_at' => microtime( true ) - 1,
+			]
+		);
+
+		self::assertSame( [], $google_api_client->requested_place_ids );
+		self::assertSame( [ 'place-a', 'place-b' ], $state['selected_waypoint_ids'] );
+		self::assertSame(
+			'The trip preview stopped loading more places before the request timed out. Try again or remove a few stops.',
+			$state['messages'][0]['text'] ?? ''
+		);
+	}
+
+	public function test_build_stops_loading_trip_waypoints_after_repeated_failures(): void {
+		$google_api_client = new FakePlannerGoogleApiClient(
+			[
+				'place-a' => GoogleApiResult::failure( 'place_details_unavailable', 'failed', 503 ),
+				'place-b' => GoogleApiResult::failure( 'place_details_unavailable', 'failed', 503 ),
+				'place-c' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-c', 'Gamma' ),
+					]
+				),
+			]
+		);
+		$builder           = $this->planner_state_builder( $google_api_client );
+
+		$state = $builder->build(
+			[
+				'selected_waypoint_ids' => [ 'place-a', 'place-b', 'place-c' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'                    => false,
+				'include_trip_waypoints'             => true,
+				'trip_waypoint_deadline_at'          => microtime( true ) + 60,
+				'trip_waypoint_place_details_timeout' => 4,
+				'trip_waypoint_max_failures'         => 2,
+			]
+		);
+
+		self::assertSame( [ 'place-a', 'place-b' ], $google_api_client->requested_place_ids );
+		self::assertSame( [ 'place-a', 'place-b', 'place-c' ], $state['selected_waypoint_ids'] );
+		self::assertCount( 0, $state['trip_waypoints'] );
+		self::assertSame(
+			'The trip preview stopped loading more places after repeated Google place errors. Try again later or remove any invalid stops.',
+			$state['messages'][2]['text'] ?? ''
+		);
+	}
+
+	private function planner_state_builder( GoogleApiClientInterface $google_api_client ): PlannerStateBuilder {
+		$settings = new Settings();
+
+		return new PlannerStateBuilder(
+			$settings,
+			new CategoryCatalog( $settings ),
+			$google_api_client,
+			new WaypointList( $settings ),
+			new StartContextResolver( $settings ),
+			new MapUrlBuilder(),
+			new DistanceFormatter(),
+			new RequestOriginValidator()
+		);
+	}
+
+	private function place( string $id, string $label ): array {
+		return [
+			'id'      => $id,
+			'label'   => $label,
+			'address' => $label . ' address',
+		];
+	}
+}
+
+final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
+	/** @var array<string, GoogleApiResult> */
+	private array $place_details_results;
+
+	/** @var list<string> */
+	public array $requested_place_ids = [];
+
+	/** @var list<int|null> */
+	public array $timeouts = [];
+
+	/**
+	 * @param array<string, GoogleApiResult> $place_details_results
+	 */
+	public function __construct( array $place_details_results ) {
+		$this->place_details_results = $place_details_results;
+	}
+
+	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
+		return GoogleApiResult::success(
+			[
+				'places' => [],
+			]
+		);
+	}
+
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
+		$this->requested_place_ids[] = $place_id;
+		$this->timeouts[]            = $timeout;
+
+		return $this->place_details_results[ $place_id ] ?? GoogleApiResult::failure( 'missing_place', 'missing', 404, false );
+	}
+
+	public function geocode( string $address ): GoogleApiResult {
+		return GoogleApiResult::success(
+			[
+				'latitude'  => 33.4484,
+				'longitude' => -112.0740,
+			]
+		);
+	}
+}

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -113,9 +113,79 @@ if ( ! function_exists( 'update_option' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( string $transient ): mixed {
+		return $GLOBALS['plan_your_day_test_transients'][ $transient ] ?? false;
+	}
+}
+
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( string $transient, mixed $value, int $expiration ): bool {
+		$GLOBALS['plan_your_day_test_transients'][ $transient ] = $value;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( string $transient ): bool {
+		unset( $GLOBALS['plan_your_day_test_transients'][ $transient ] );
+
+		return true;
+	}
+}
+
 if ( ! function_exists( 'wp_parse_url' ) ) {
 	function wp_parse_url( string $url, int $component = -1 ): mixed {
 		return parse_url( $url, $component );
+	}
+}
+
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( mixed $value ): string|false {
+		return json_encode( $value );
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( mixed $thing ): bool {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( array $response ): int {
+		return (int) ( $response['response']['code'] ?? 0 );
+	}
+}
+
+if ( ! function_exists( 'wp_remote_retrieve_body' ) ) {
+	function wp_remote_retrieve_body( array $response ): string {
+		return (string) ( $response['body'] ?? '' );
+	}
+}
+
+if ( ! function_exists( 'add_query_arg' ) ) {
+	function add_query_arg( array $args, string $url ): string {
+		$query = http_build_query( $args );
+
+		if ( '' === $query ) {
+			return $url;
+		}
+
+		return $url . ( str_contains( $url, '?' ) ? '&' : '?' ) . $query;
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( string $url ): string {
+		return $url;
+	}
+}
+
+if ( ! function_exists( '_n' ) ) {
+	function _n( string $single, string $plural, int $number, ?string $domain = null ): string {
+		return 1 === $number ? $single : $plural;
 	}
 }
 


### PR DESCRIPTION
## What changed
This bounds public trip waypoint resolution for the planner REST endpoints.

The change adds:
- a shorter per-call timeout override for Google Place Details lookups
- an aggregate deadline for public trip waypoint loading
- a failure cap so repeated Place Details misses stop additional outbound work
- focused PHPUnit coverage for the timeout override and the bounded waypoint-resolution path

## Why it changed
Issue #45 identified that one allowed planner request could fan out into many sequential Google Place Details calls and hold a PHP worker for too long when Google is slow or degraded.

## Impact
Public planner `browse` and `route` requests now stop additional waypoint-detail work once the request budget is exhausted or repeated failures occur. Cached and successful small trips should continue to behave normally, while worst-case uncached requests are bounded more tightly.

## Root cause
The planner state builder resolved every selected waypoint sequentially with the full configured Google API timeout and no route-level deadline or failure cutoff.

## Validation
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter GoogleApiClientTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter PlannerStateBuilderTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh tools/lint.php`

## Notes
- `phpcs` could not run in this environment because the available CLI PHP is missing the `xmlwriter` and `SimpleXML` extensions required by PHP_CodeSniffer.
- This PR targets `feat/issue-37-quality-checks` so the diff stays isolated from the unrelated commits already on that branch.