### PR TITLE
[codex] Guard initial planner hydration

### DIFF
--- a/plugin/plan-your-day/assets/js/plan.js
+++ b/plugin/plan-your-day/assets/js/plan.js
@@ -208,10 +208,12 @@
     const tripWaypoints = Array.isArray(routeData?.tripWaypoints) ? routeData.tripWaypoints : [];
 
     if (tripWaypoints.length === 0) {
+      const tripEmptyState = routeData?.tripEmptyState || {};
+
       return `
         <div class="plan-your-day__trip-empty" data-plan-trip-empty>
-          <h4>${escapeHtml(strings.tripEmptyHeading || '')}</h4>
-          <p>${escapeHtml(strings.tripEmptyBody || '')}</p>
+          <h4>${escapeHtml(tripEmptyState.heading || strings.tripEmptyHeading || '')}</h4>
+          <p>${escapeHtml(tripEmptyState.body || strings.tripEmptyBody || '')}</p>
         </div>
       `;
     }
@@ -592,11 +594,11 @@
       config.rest.routeUrl !== '' &&
       typeof config.rest?.endpointToken === 'string' &&
       config.rest.endpointToken !== '';
+    const shouldHydrateOnLoad = Boolean(config.hydration?.shouldHydrateOnLoad);
 
     let isStartPanelOpen = true;
     let activeRequestController = null;
     let activeRequestId = 0;
-    let allowNativeSubmit = false;
 
     const renderAll = () => {
       renderCategoryPanels(refs, state, strings);
@@ -629,25 +631,6 @@
       if (refs.startToggleLabel) {
         refs.startToggleLabel.textContent = isStartPanelOpen ? 'Hide' : 'Show';
       }
-    };
-
-    const submitFormFallback = (submitter = null) => {
-      if (!(refs.form instanceof HTMLFormElement)) {
-        return;
-      }
-
-      debugLog(config, 'warn', 'request:fallback-submit', {
-        submitterName: submitter instanceof HTMLElement ? submitter.getAttribute('name') || '' : '',
-        submitterValue: submitter instanceof HTMLElement ? submitter.getAttribute('value') || '' : '',
-      });
-      allowNativeSubmit = true;
-
-      if (submitter instanceof HTMLElement && typeof refs.form.requestSubmit === 'function') {
-        refs.form.requestSubmit(submitter);
-        return;
-      }
-
-      refs.form.submit();
     };
 
     const sendRequest = async (endpointKey, payload, announcementMessage) => {
@@ -766,11 +749,7 @@
           return;
         }
 
-        void sendRequest('browse', buildPayload(refs, state), strings.startingPointUpdated || '').then((status) => {
-          if (status === 'failed') {
-            submitFormFallback();
-          }
-        });
+        void sendRequest('browse', buildPayload(refs, state), strings.startingPointUpdated || '');
       });
     });
 
@@ -784,11 +763,7 @@
           return;
         }
 
-        void sendRequest('browse', buildPayload(refs, state), strings.startingPointUpdated || '').then((status) => {
-          if (status === 'failed') {
-            submitFormFallback();
-          }
-        });
+        void sendRequest('browse', buildPayload(refs, state), strings.startingPointUpdated || '');
       });
     }
 
@@ -810,21 +785,12 @@
         state.expandedCategory = '';
         state.customResultsExpanded = true;
 
-        void sendRequest('browse', payload, strings.resultsUpdated || '').then((status) => {
-          if (status === 'failed') {
-            submitFormFallback();
-          }
-        });
+        void sendRequest('browse', payload, strings.resultsUpdated || '');
       });
     }
 
     if (refs.form instanceof HTMLFormElement) {
       refs.form.addEventListener('submit', (event) => {
-        if (allowNativeSubmit) {
-          allowNativeSubmit = false;
-          return;
-        }
-
         const submitter = event.submitter;
 
         if (!(submitter instanceof HTMLButtonElement) || !hasRestConfig) {
@@ -883,11 +849,7 @@
         }
 
         event.preventDefault();
-        void sendRequest(endpointKey, payload, announcementMessage).then((status) => {
-          if (status === 'failed') {
-            submitFormFallback(submitter);
-          }
-        });
+        void sendRequest(endpointKey, payload, announcementMessage);
       });
     }
 
@@ -943,6 +905,15 @@
     renderAll();
     updateStartPanelState();
     root.classList.add('is-enhanced');
+
+    if (shouldHydrateOnLoad) {
+      if (!hasRestConfig) {
+        showRequestError(strings.requestFailed || '');
+        return;
+      }
+
+      void sendRequest('browse', buildPayload(refs, state), '');
+    }
   };
 
   const init = () => {

--- a/plugin/plan-your-day/src/Frontend/InitialPlannerHydration.php
+++ b/plugin/plan-your-day/src/Frontend/InitialPlannerHydration.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Frontend;
+
+use Acodebeard\PlanYourDay\Planner\PlaceParser;
+
+defined( 'ABSPATH' ) || exit;
+
+final class InitialPlannerHydration {
+	public static function build_render_state_options(): array {
+		return [
+			'include_results'        => false,
+			'include_trip_waypoints' => false,
+		];
+	}
+
+	public static function should_hydrate_on_load( array $request_state ): bool {
+		$category_key      = sanitize_key( (string) ( $request_state['category_key'] ?? '' ) );
+		$category_search   = trim( sanitize_text_field( (string) ( $request_state['category_search'] ?? '' ) ) );
+		$selected_waypoints = array_filter(
+			array_map(
+				static function ( mixed $waypoint_id ): string {
+					return PlaceParser::sanitize_place_id( (string) $waypoint_id );
+				},
+				(array) ( $request_state['selected_waypoint_ids'] ?? [] )
+			)
+		);
+
+		return '' !== $category_key || '' !== $category_search || [] !== $selected_waypoints;
+	}
+
+	public static function apply_loading_placeholders( array $planner_state ): array {
+		$has_search             = ! empty( $planner_state['has_search'] );
+		$has_selected_waypoints = [] !== array_filter(
+			array_map(
+				static function ( mixed $waypoint_id ): string {
+					return PlaceParser::sanitize_place_id( (string) $waypoint_id );
+				},
+				(array) ( $planner_state['selected_waypoint_ids'] ?? [] )
+			)
+		);
+		$messages               = is_array( $planner_state['messages'] ?? null ) ? array_values( $planner_state['messages'] ) : [];
+
+		$messages[] = [
+			'type' => 'note',
+			'text' => __( 'Loading planner state through a verified request.', 'plan-your-day' ),
+		];
+
+		$planner_state['messages'] = $messages;
+
+		if ( $has_search ) {
+			$planner_state['search_results_label'] = __( 'Loading Google results...', 'plan-your-day' );
+			$planner_state['results_empty_state']  = [
+				'heading' => __( 'Loading Google results', 'plan-your-day' ),
+				'body'    => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+			];
+			$planner_state['overview']             = __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' );
+		}
+
+		if ( $has_selected_waypoints ) {
+			$planner_state['trip_count_label'] = __( 'Loading trip waypoints...', 'plan-your-day' );
+			$planner_state['trip_empty_state'] = [
+				'heading' => __( 'Loading trip waypoints', 'plan-your-day' ),
+				'body'    => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+			];
+			$planner_state['overview']         = __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' );
+		}
+
+		if ( $has_selected_waypoints ) {
+			$planner_state['preview_mode_label']  = __( 'Loading trip preview', 'plan-your-day' );
+			$planner_state['preview_empty_state'] = [
+				'heading' => __( 'Loading trip preview', 'plan-your-day' ),
+				'body'    => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+			];
+		} elseif ( $has_search ) {
+			$planner_state['preview_mode_label']  = __( 'Loading search preview', 'plan-your-day' );
+			$planner_state['preview_empty_state'] = [
+				'heading' => __( 'Loading search preview', 'plan-your-day' ),
+				'body'    => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+			];
+		}
+
+		return $planner_state;
+	}
+}

--- a/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
+++ b/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
@@ -45,12 +45,25 @@ final class PlannerRenderer {
 			return $this->render_setup_notice( $instance_id, $title_id );
 		}
 
-		$request_state       = $this->request_state_parser->parse( $request );
-		$planner_state       = $this->planner_state_builder->build( $request_state );
+		$request_state           = $this->request_state_parser->parse( $request );
+		$should_hydrate_on_load = InitialPlannerHydration::should_hydrate_on_load( $request_state );
+		$planner_state           = $this->planner_state_builder->build(
+			$request_state,
+			InitialPlannerHydration::build_render_state_options()
+		);
+
+		if ( $should_hydrate_on_load ) {
+			$planner_state = InitialPlannerHydration::apply_loading_placeholders( $planner_state );
+		}
+
 		$category_catalog    = $this->category_catalog->get_all();
 		$start_points        = $this->get_start_points();
-		$results_empty_state = $this->planner_payload_builder->get_empty_results_state( $planner_state );
-		$preview_empty_state = $this->planner_payload_builder->get_empty_preview_state( $planner_state );
+		$results_empty_state = isset( $planner_state['results_empty_state'] )
+			? (array) $planner_state['results_empty_state']
+			: $this->planner_payload_builder->get_empty_results_state( $planner_state );
+		$preview_empty_state = isset( $planner_state['preview_empty_state'] )
+			? (array) $planner_state['preview_empty_state']
+			: $this->planner_payload_builder->get_empty_preview_state( $planner_state );
 		$action_url          = '' !== $action_url ? $action_url : $this->get_current_url();
 		$form_action         = $action_url . '#' . $instance_id;
 		$maps_link_enabled   = '' !== $planner_state['maps_url'];
@@ -95,7 +108,7 @@ final class PlannerRenderer {
 				</form>
 			</div>
 
-			<script type="application/json" data-plan-config><?php echo wp_json_encode( $this->build_config( $instance_id, $action_url, $planner_state, $start_points, $category_catalog, $endpoint_token ) ); ?></script>
+			<script type="application/json" data-plan-config><?php echo wp_json_encode( $this->build_config( $instance_id, $action_url, $planner_state, $start_points, $category_catalog, $endpoint_token, $should_hydrate_on_load ) ); ?></script>
 		</section>
 		<?php
 
@@ -429,9 +442,15 @@ final class PlannerRenderer {
 	}
 
 	private function render_trip_card( string $instance_id, array $planner_state ): void {
-		$heading_id = $instance_id . '-trip-heading';
-		$help_id    = $instance_id . '-trip-help';
-		$waypoints  = (array) $planner_state['trip_waypoints'];
+		$heading_id       = $instance_id . '-trip-heading';
+		$help_id          = $instance_id . '-trip-help';
+		$waypoints        = (array) $planner_state['trip_waypoints'];
+		$trip_empty_state = isset( $planner_state['trip_empty_state'] )
+			? (array) $planner_state['trip_empty_state']
+			: [
+				'heading' => __( 'Start building the trip', 'plan-your-day' ),
+				'body'    => __( 'Search Google by category, then add the exact places you want as walking-trip waypoints.', 'plan-your-day' ),
+			];
 		?>
 		<section class="plan-your-day__card" aria-labelledby="<?php echo esc_attr( $heading_id ); ?>">
 			<div class="plan-your-day__card-header">
@@ -458,8 +477,8 @@ final class PlannerRenderer {
 					</ol>
 				<?php else : ?>
 					<div class="plan-your-day__trip-empty" data-plan-trip-empty>
-						<h4><?php esc_html_e( 'Start building the trip', 'plan-your-day' ); ?></h4>
-						<p><?php esc_html_e( 'Search Google by category, then add the exact places you want as walking-trip waypoints.', 'plan-your-day' ); ?></p>
+						<h4><?php echo esc_html( $trip_empty_state['heading'] ); ?></h4>
+						<p><?php echo esc_html( $trip_empty_state['body'] ); ?></p>
 					</div>
 				<?php endif; ?>
 			</div>
@@ -635,7 +654,22 @@ final class PlannerRenderer {
 		return $start_points;
 	}
 
-	private function build_config( string $instance_id, string $action_url, array $planner_state, array $start_points, array $category_catalog, string $endpoint_token ): array {
+	private function build_config( string $instance_id, string $action_url, array $planner_state, array $start_points, array $category_catalog, string $endpoint_token, bool $should_hydrate_on_load ): array {
+		$browse_payload = $this->planner_payload_builder->build_browse_payload( $planner_state );
+		$route_payload  = $this->planner_payload_builder->build_route_payload( $planner_state );
+
+		if ( isset( $planner_state['results_empty_state'] ) ) {
+			$browse_payload['resultsEmptyState'] = (array) $planner_state['results_empty_state'];
+		}
+
+		if ( isset( $planner_state['preview_empty_state'] ) ) {
+			$route_payload['emptyPreviewState'] = (array) $planner_state['preview_empty_state'];
+		}
+
+		if ( isset( $planner_state['trip_empty_state'] ) ) {
+			$route_payload['tripEmptyState'] = (array) $planner_state['trip_empty_state'];
+		}
+
 		return [
 			'actionUrl'       => $action_url,
 			'sectionId'       => $instance_id,
@@ -645,6 +679,9 @@ final class PlannerRenderer {
 				'browseUrl'      => rest_url( PlannerRoutes::REST_NAMESPACE . '/browse' ),
 				'routeUrl'       => rest_url( PlannerRoutes::REST_NAMESPACE . '/route' ),
 				'endpointToken'  => $endpoint_token,
+			],
+			'hydration'       => [
+				'shouldHydrateOnLoad' => $should_hydrate_on_load,
 			],
 			'strings'         => [
 				'requestFailed'       => __( 'The planner request could not be completed. Refresh the page and try again.', 'plan-your-day' ),
@@ -702,8 +739,8 @@ final class PlannerRenderer {
 				'customStart'         => $planner_state['custom_start'],
 			],
 			'initialData'     => [
-				'browse' => $this->planner_payload_builder->build_browse_payload( $planner_state ),
-				'route'  => $this->planner_payload_builder->build_route_payload( $planner_state ),
+				'browse' => $browse_payload,
+				'route'  => $route_payload,
 			],
 		];
 	}

--- a/plugin/plan-your-day/tests/InitialPlannerHydrationTest.php
+++ b/plugin/plan-your-day/tests/InitialPlannerHydrationTest.php
@@ -1,0 +1,84 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Frontend\InitialPlannerHydration;
+use PHPUnit\Framework\TestCase;
+
+final class InitialPlannerHydrationTest extends TestCase {
+	public function test_build_render_state_options_disable_remote_get_work(): void {
+		self::assertSame(
+			[
+				'include_results'        => false,
+				'include_trip_waypoints' => false,
+			],
+			InitialPlannerHydration::build_render_state_options()
+		);
+	}
+
+	public function test_should_hydrate_on_load_for_search_and_trip_state(): void {
+		self::assertTrue(
+			InitialPlannerHydration::should_hydrate_on_load(
+				[
+					'category_key'          => 'coffee',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [],
+				]
+			)
+		);
+		self::assertTrue(
+			InitialPlannerHydration::should_hydrate_on_load(
+				[
+					'category_key'          => '',
+					'category_search'       => 'coffee',
+					'selected_waypoint_ids' => [],
+				]
+			)
+		);
+		self::assertTrue(
+			InitialPlannerHydration::should_hydrate_on_load(
+				[
+					'category_key'          => '',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [ 'place-1' ],
+				]
+			)
+		);
+	}
+
+	public function test_should_not_hydrate_on_load_for_start_only_state(): void {
+		self::assertFalse(
+			InitialPlannerHydration::should_hydrate_on_load(
+				[
+					'category_key'          => '',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [],
+					'start_mode'            => 'custom',
+					'custom_start'          => 'Hotel',
+				]
+			)
+		);
+	}
+
+	public function test_apply_loading_placeholders_sets_search_and_trip_loading_copy(): void {
+		$planner_state = InitialPlannerHydration::apply_loading_placeholders(
+			[
+				'has_search'            => true,
+				'selected_waypoint_ids' => [ 'place-1' ],
+				'search_results_label'  => '0 Google results',
+				'trip_count_label'      => 'Trip not started',
+				'overview'              => 'Original overview',
+				'preview_mode_label'    => 'Google place search',
+				'messages'              => [],
+			]
+		);
+
+		self::assertSame( 'Loading Google results...', $planner_state['search_results_label'] );
+		self::assertSame( 'Loading trip waypoints...', $planner_state['trip_count_label'] );
+		self::assertSame( 'Loading Google results', $planner_state['results_empty_state']['heading'] );
+		self::assertSame( 'Loading trip waypoints', $planner_state['trip_empty_state']['heading'] );
+		self::assertSame( 'Loading trip preview', $planner_state['preview_empty_state']['heading'] );
+		self::assertSame( 'Loading planner state through a verified request.', $planner_state['messages'][0]['text'] );
+	}
+}

--- a/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
+++ b/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
@@ -134,6 +134,36 @@ final class PlannerStateBuilderTest extends TestCase {
 		);
 	}
 
+	public function test_build_skips_remote_work_when_results_and_trip_waypoints_are_disabled(): void {
+		$google_api_client = new FakePlannerGoogleApiClient(
+			[
+				'place-a' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-a', 'Alpha' ),
+					]
+				),
+			]
+		);
+		$builder           = $this->planner_state_builder( $google_api_client );
+
+		$state = $builder->build(
+			[
+				'category_search'       => 'coffee',
+				'selected_waypoint_ids' => [ 'place-a' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'        => false,
+				'include_trip_waypoints' => false,
+			]
+		);
+
+		self::assertSame( [], $google_api_client->requested_place_ids );
+		self::assertSame( 0, $google_api_client->text_search_calls );
+		self::assertSame( 0, $google_api_client->geocode_calls );
+		self::assertSame( [ 'place-a' ], $state['selected_waypoint_ids'] );
+	}
+
 	private function planner_state_builder( GoogleApiClientInterface $google_api_client ): PlannerStateBuilder {
 		$settings = new Settings();
 
@@ -168,6 +198,10 @@ final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
 	/** @var list<int|null> */
 	public array $timeouts = [];
 
+	public int $text_search_calls = 0;
+
+	public int $geocode_calls = 0;
+
 	/**
 	 * @param array<string, GoogleApiResult> $place_details_results
 	 */
@@ -176,6 +210,8 @@ final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
+		++$this->text_search_calls;
+
 		return GoogleApiResult::success(
 			[
 				'places' => [],
@@ -191,6 +227,8 @@ final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	public function geocode( string $address ): GoogleApiResult {
+		++$this->geocode_calls;
+
 		return GoogleApiResult::success(
 			[
 				'latitude'  => 33.4484,


### PR DESCRIPTION
## What changed
This removes provider-backed planner work from the initial full-page GET render and shifts state restoration onto the guarded REST path.

The change adds:
- a small frontend hydration helper that disables remote work during server-side GET rendering
- loading placeholders for bookmarked/shared planner state until the guarded REST request finishes
- client-side hydration on page load through the existing guarded `browse` endpoint
- removal of the native form-submit fallback after REST failures so 403/429/server errors do not drop into the GET path
- focused PHPUnit coverage for the hydration decision logic and the no-remote-work render options

## Why it changed
Issue #44 identified that the shortcode render path accepted `$_GET` state and built provider-backed planner data without going through the REST origin/token/rate-limit guard. The frontend also fell back to native GET submits after REST failures, reopening that unguarded path.

## Impact
Initial page loads still preserve planner state in the UI, but Google-backed results and waypoint details now load only through guarded REST requests after the page is enhanced. If REST fails, the UI keeps its current state and shows the error instead of retrying via a native GET submit.

## Root cause
The server render path and the guarded REST path both used the same state builder, but only the REST path enforced origin validation, endpoint token checks, and rate limiting.

## Validation
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter InitialPlannerHydrationTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter PlannerStateBuilderTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh tools/lint.php`

## Notes
- `phpcs` could not run in this environment because the available CLI PHP is missing the `xmlwriter` and `SimpleXML` extensions required by PHP_CodeSniffer.
- The unrelated untracked `API-RESILIENCE-ABUSE-REVIEW.md` file was left untouched.