### PR TITLE
[codex] Harden REST rate limiting

### DIFF
--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -10,14 +10,21 @@ defined( 'ABSPATH' ) || exit;
 
 final class RateLimiter {
 	private const WINDOW_SECONDS = 60;
-	private const CACHE_DIR_NAME = 'plan_your_day_rate';
+	private const STATE_OPTION_PREFIX = 'plan_your_day_rate_';
+	private const LOCK_OPTION_PREFIX = 'plan_your_day_rate_lock_';
+	private const LOCK_TIMEOUT_SECONDS = 5.0;
+	private const LOCK_RETRY_ATTEMPTS = 5;
+	private const LOCK_RETRY_DELAY_MICROSECONDS = 20000;
 
 	private Settings $settings;
 	private ClientIpResolver $client_ip_resolver;
+	/** @var callable */
+	private $time_provider;
 
-	public function __construct( Settings $settings, ClientIpResolver $client_ip_resolver ) {
+	public function __construct( Settings $settings, ClientIpResolver $client_ip_resolver, ?callable $time_provider = null ) {
 		$this->settings           = $settings;
 		$this->client_ip_resolver = $client_ip_resolver;
+		$this->time_provider      = $time_provider ?? static fn (): float => microtime( true );
 	}
 
 	public function enforce( string $scope, array $server = [] ): ?WP_Error {
@@ -28,24 +35,111 @@ final class RateLimiter {
 			$ip = 'unknown';
 		}
 
-		$bucket    = (int) floor( time() / self::WINDOW_SECONDS );
-		$key       = hash( 'sha256', $scope . '|' . $ip . '|' . $bucket );
-		$cache_key = self::CACHE_DIR_NAME . '_' . $key;
-		$count     = (int) get_transient( $cache_key );
+		$key = hash( 'sha256', $scope . '|' . $ip );
+		$now = $this->now();
 
-		if ( $count >= $limit ) {
-			return new WP_Error(
-				'plan_your_day_rate_limited',
-				__( 'Planner requests are temporarily limited. Please wait a minute and try again.', 'plan-your-day' ),
-				[
-					'status' => 429,
-				]
-			);
+		if ( ! $this->acquire_lock( $key, $now ) ) {
+			return $this->rate_limited_error();
 		}
 
-		$count++;
-		set_transient( $cache_key, $count, self::WINDOW_SECONDS * 2 );
+		try {
+			$window_start = $now - self::WINDOW_SECONDS;
+			$timestamps   = array_values(
+				array_filter(
+					$this->load_state( $key ),
+					static function ( mixed $timestamp ) use ( $window_start ): bool {
+						return is_numeric( $timestamp ) && (float) $timestamp > $window_start;
+					}
+				)
+			);
+
+			if ( count( $timestamps ) >= $limit ) {
+				$this->persist_state( $key, $timestamps );
+
+				return $this->rate_limited_error();
+			}
+
+			$timestamps[] = $now;
+			$this->persist_state( $key, $timestamps );
+		} finally {
+			$this->release_lock( $key );
+		}
 
 		return null;
+	}
+
+	private function now(): float {
+		return (float) call_user_func( $this->time_provider );
+	}
+
+	private function state_option_name( string $key ): string {
+		return self::STATE_OPTION_PREFIX . $key;
+	}
+
+	private function lock_option_name( string $key ): string {
+		return self::LOCK_OPTION_PREFIX . $key;
+	}
+
+	private function load_state( string $key ): array {
+		$state = get_option( $this->state_option_name( $key ), [] );
+
+		return is_array( $state ) ? $state : [];
+	}
+
+	private function persist_state( string $key, array $timestamps ): void {
+		$option_name = $this->state_option_name( $key );
+		$timestamps  = array_values(
+			array_map(
+				static function ( mixed $timestamp ): float {
+					return (float) $timestamp;
+				},
+				$timestamps
+			)
+		);
+
+		if ( [] === $timestamps ) {
+			delete_option( $option_name );
+			return;
+		}
+
+		update_option( $option_name, $timestamps, false );
+	}
+
+	private function acquire_lock( string $key, float $now ): bool {
+		$option_name = $this->lock_option_name( $key );
+
+		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
+			if ( add_option( $option_name, $now + self::LOCK_TIMEOUT_SECONDS, '', false ) ) {
+				return true;
+			}
+
+			$locked_until = get_option( $option_name, 0 );
+
+			if ( is_numeric( $locked_until ) && (float) $locked_until <= $now ) {
+				delete_option( $option_name );
+				continue;
+			}
+
+			if ( $attempt < self::LOCK_RETRY_ATTEMPTS - 1 ) {
+				usleep( self::LOCK_RETRY_DELAY_MICROSECONDS );
+				$now = $this->now();
+			}
+		}
+
+		return false;
+	}
+
+	private function release_lock( string $key ): void {
+		delete_option( $this->lock_option_name( $key ) );
+	}
+
+	private function rate_limited_error(): WP_Error {
+		return new WP_Error(
+			'plan_your_day_rate_limited',
+			__( 'Planner requests are temporarily limited. Please wait a minute and try again.', 'plan-your-day' ),
+			[
+				'status' => 429,
+			]
+		);
 	}
 }

--- a/plugin/plan-your-day/tests/RateLimiterTest.php
+++ b/plugin/plan-your-day/tests/RateLimiterTest.php
@@ -1,0 +1,85 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Security\ClientIpResolver;
+use Acodebeard\PlanYourDay\Security\RateLimiter;
+use Acodebeard\PlanYourDay\Settings\Settings;
+use PHPUnit\Framework\TestCase;
+use WP_Error;
+
+final class RateLimiterTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['plan_your_day_test_options'] = [];
+	}
+
+	public function test_enforce_allows_requests_until_the_limit_then_blocks(): void {
+		$now     = 1000.0;
+		$limiter = $this->build_limiter( 2, $now );
+
+		self::assertNull( $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+		self::assertNull( $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+
+		$error = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
+		self::assertSame( 429, $error->get_error_data()['status'] ?? null );
+	}
+
+	public function test_enforce_uses_a_rolling_window_instead_of_a_fixed_bucket_boundary(): void {
+		$now     = 59.8;
+		$limiter = $this->build_limiter( 2, $now );
+
+		self::assertNull( $limiter->enforce( 'route', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+
+		$now = 59.9;
+		self::assertNull( $limiter->enforce( 'route', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+
+		$now   = 60.1;
+		$error = $limiter->enforce( 'route', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
+	}
+
+	public function test_enforce_recovers_from_a_stale_lock(): void {
+		$now = 200.0;
+		update_option(
+			'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
+			150.0
+		);
+		$limiter = $this->build_limiter( 2, $now );
+
+		$result = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertNull( $result );
+		self::assertFalse(
+			array_key_exists(
+				'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
+				$GLOBALS['plan_your_day_test_options']
+			)
+		);
+	}
+
+	private function build_limiter( int $limit, float &$now ): RateLimiter {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'rate_limit_per_minute' => $limit,
+				]
+			)
+		);
+
+		return new RateLimiter(
+			new Settings(),
+			new ClientIpResolver( new Settings() ),
+			static function () use ( &$now ): float {
+				return $now;
+			}
+		);
+	}
+}

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -106,8 +106,28 @@ if ( ! function_exists( 'get_option' ) ) {
 }
 
 if ( ! function_exists( 'update_option' ) ) {
-	function update_option( string $option_name, mixed $value ): bool {
+	function update_option( string $option_name, mixed $value, mixed $autoload = null ): bool {
 		$GLOBALS['plan_your_day_test_options'][ $option_name ] = $value;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_option' ) ) {
+	function add_option( string $option_name, mixed $value, string $deprecated = '', mixed $autoload = null ): bool {
+		if ( array_key_exists( $option_name, $GLOBALS['plan_your_day_test_options'] ) ) {
+			return false;
+		}
+
+		$GLOBALS['plan_your_day_test_options'][ $option_name ] = $value;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( string $option_name ): bool {
+		unset( $GLOBALS['plan_your_day_test_options'][ $option_name ] );
 
 		return true;
 	}


### PR DESCRIPTION
## What changed
This hardens the planner REST rate limiter so enforcement is serialized and based on a rolling 60-second window instead of a fixed bucket.

The change adds:
- a lock-guarded limiter state update keyed by scope and client IP
- rolling-window request timestamps instead of a fixed minute bucket
- stale-lock recovery so abandoned locks do not wedge the limiter
- focused PHPUnit coverage for enforcement, stale-lock recovery, and the former bucket-boundary burst case

## Why it changed
Issue #46 identified that the limiter used a non-atomic read/compare/write transient counter and a fixed window. Under concurrency, multiple requests could observe the same count before any write landed, and requests clustered around bucket boundaries could exceed the intended rate.

## Impact
Planner REST requests should now respect the configured per-minute rate more closely under contention, and the classic fixed-window burst behavior is reduced because the limiter evaluates the last 60 seconds of traffic rather than a bucket boundary.

## Root cause
The previous implementation stored one transient count per `(scope, ip, minute-bucket)` and incremented it with separate read and write operations.

## Validation
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter RateLimiterTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `php tools/lint.php src/Security/RateLimiter.php tests/RateLimiterTest.php tests/bootstrap.php`

## Notes
- `phpcs` could not run in this environment because the available CLI PHP is missing the `xmlwriter` and `SimpleXML` extensions required by PHP_CodeSniffer.
- The unrelated untracked `API-RESILIENCE-ABUSE-REVIEW.md` file was left untouched.