### PR TITLE
[codex] Serialize route mutations in the planner

### DIFF
--- a/plugin/plan-your-day/assets/js/plan.js
+++ b/plugin/plan-your-day/assets/js/plan.js
@@ -174,7 +174,7 @@
                     ? `<span class="plan-your-day__result-added" aria-label="${escapeHtml(formatString(strings.alreadyInTripAria, label))}">${escapeHtml(strings.inTrip || '')}</span>`
                     : `<button class="plan-your-day__result-add" type="submit" name="waypoints[]" value="${escapeHtml(
                         placeId
-                      )}" data-plan-action="add-waypoint" data-place-id="${escapeHtml(placeId)}" aria-label="${escapeHtml(
+                      )}" data-plan-action="add-waypoint" data-plan-route-mutation data-place-id="${escapeHtml(placeId)}" aria-label="${escapeHtml(
                         formatString(strings.addWaypointLabel || '', label)
                       )}">${escapeHtml(
                         strings.addToTrip || ''
@@ -196,7 +196,7 @@
       <span class="plan-your-day__count-pill" data-plan-trip-count>${escapeHtml(tripCountLabel)}</span>
       ${
         selectedWaypointIds.length > 0
-          ? `<button class="plan-your-day__clear-link" type="submit" name="clear_trip" value="1" data-plan-clear-trip data-plan-action="clear-trip">${escapeHtml(
+          ? `<button class="plan-your-day__clear-link" type="submit" name="clear_trip" value="1" data-plan-clear-trip data-plan-action="clear-trip" data-plan-route-mutation>${escapeHtml(
               strings.clearTrip || ''
             )}</button>`
           : ''
@@ -243,6 +243,7 @@
                     type="${canMoveUp ? 'submit' : 'button'}"
                     name="move_waypoint"
                     value="${escapeHtml(`${placeId}:up`)}"
+                    data-plan-route-mutation
                     aria-label="${escapeHtml(formatString(strings.moveWaypointUpLabel || '', label))}"
                     ${canMoveUp ? '' : 'disabled'}>
                     ${escapeHtml(strings.moveUp || '')}
@@ -252,13 +253,14 @@
                     type="${canMoveDown ? 'submit' : 'button'}"
                     name="move_waypoint"
                     value="${escapeHtml(`${placeId}:down`)}"
+                    data-plan-route-mutation
                     aria-label="${escapeHtml(formatString(strings.moveWaypointDownLabel || '', label))}"
                     ${canMoveDown ? '' : 'disabled'}>
                     ${escapeHtml(strings.moveDown || '')}
                   </button>
                   <button type="submit" name="remove_waypoint" value="${escapeHtml(
                     placeId
-                  )}" data-plan-action="remove-waypoint" data-place-id="${escapeHtml(placeId)}">
+                  )}" data-plan-action="remove-waypoint" data-plan-route-mutation data-place-id="${escapeHtml(placeId)}">
                     ${escapeHtml(formatString(strings.removeWaypointLabel, label))}
                   </button>
                 </div>
@@ -499,6 +501,32 @@
     root.setAttribute('aria-busy', String(isBusy));
   };
 
+  const setRouteMutationBusyState = (root, isBusy) => {
+    root.querySelectorAll('[data-plan-route-mutation]').forEach((control) => {
+      if (!(control instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      if (isBusy) {
+        if (!control.hasAttribute('data-plan-disabled-before-request')) {
+          control.setAttribute('data-plan-disabled-before-request', control.disabled ? 'true' : 'false');
+        }
+
+        control.disabled = true;
+        return;
+      }
+
+      const disabledBeforeRequest = control.getAttribute('data-plan-disabled-before-request');
+
+      if (null === disabledBeforeRequest) {
+        return;
+      }
+
+      control.disabled = disabledBeforeRequest === 'true';
+      control.removeAttribute('data-plan-disabled-before-request');
+    });
+  };
+
   const setRegionBusyState = (refs, state, isBusy) => {
     const activeCategory = state.category || '';
 
@@ -607,6 +635,7 @@
       syncHiddenInputs(refs, state);
       syncStartUi(refs, config, state);
       syncCategorySearchUi(refs, state);
+      setRouteMutationBusyState(root, false);
     };
 
     const showRequestError = (message) => {
@@ -648,6 +677,7 @@
       activeRequestController = new AbortController();
       setBusyState(root, true);
       setRegionBusyState(refs, state, true);
+      setRouteMutationBusyState(root, endpointKey === 'route');
       debugLog(config, 'info', 'request:start', {
         endpointKey,
         payload,
@@ -735,6 +765,7 @@
         if (requestId === activeRequestId) {
           setBusyState(root, false);
           setRegionBusyState(refs, state, false);
+          setRouteMutationBusyState(root, false);
         }
       }
     };

--- a/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
+++ b/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
@@ -426,6 +426,7 @@ final class PlannerRenderer {
 						name="waypoints[]"
 							value="<?php echo esc_attr( $place_id ); ?>"
 							data-plan-action="add-waypoint"
+							data-plan-route-mutation
 							data-place-id="<?php echo esc_attr( $place_id ); ?>"
 							aria-label="
 							<?php
@@ -461,7 +462,7 @@ final class PlannerRenderer {
 				<div class="plan-your-day__trip-header-actions" data-plan-trip-header-actions>
 					<span class="plan-your-day__count-pill" data-plan-trip-count><?php echo esc_html( $planner_state['trip_count_label'] ); ?></span>
 					<?php if ( [] !== (array) $planner_state['selected_waypoint_ids'] ) : ?>
-						<button class="plan-your-day__clear-link" type="submit" name="clear_trip" value="1" data-plan-clear-trip data-plan-action="clear-trip">
+						<button class="plan-your-day__clear-link" type="submit" name="clear_trip" value="1" data-plan-clear-trip data-plan-action="clear-trip" data-plan-route-mutation>
 							<?php esc_html_e( 'Clear trip', 'plan-your-day' ); ?>
 						</button>
 					<?php endif; ?>
@@ -504,6 +505,7 @@ final class PlannerRenderer {
 						type="<?php echo $index > 0 ? 'submit' : 'button'; ?>"
 						name="move_waypoint"
 						value="<?php echo esc_attr( $place_id . ':up' ); ?>"
+						data-plan-route-mutation
 						aria-label="
 						<?php
 						/* translators: %s is a place label. */
@@ -518,6 +520,7 @@ final class PlannerRenderer {
 						type="<?php echo $index < $waypoint_count - 1 ? 'submit' : 'button'; ?>"
 						name="move_waypoint"
 						value="<?php echo esc_attr( $place_id . ':down' ); ?>"
+						data-plan-route-mutation
 						aria-label="
 						<?php
 						/* translators: %s is a place label. */
@@ -527,7 +530,7 @@ final class PlannerRenderer {
 					<?php disabled( $index >= $waypoint_count - 1 ); ?>>
 					<?php esc_html_e( 'Move down', 'plan-your-day' ); ?>
 					</button>
-					<button type="submit" name="remove_waypoint" value="<?php echo esc_attr( $place_id ); ?>" data-plan-action="remove-waypoint" data-place-id="<?php echo esc_attr( $place_id ); ?>">
+					<button type="submit" name="remove_waypoint" value="<?php echo esc_attr( $place_id ); ?>" data-plan-action="remove-waypoint" data-plan-route-mutation data-place-id="<?php echo esc_attr( $place_id ); ?>">
 						<?php
 						/* translators: %s is a place label. */
 						echo esc_html( sprintf( __( 'Remove %s', 'plan-your-day' ), $label ) );


### PR DESCRIPTION
## What changed
This serializes route mutations in the planner UI by disabling route-mutating controls while a `route` request is in flight.

The change adds:
- a dedicated marker for route-mutating controls in the rendered planner markup
- client-side busy-state handling that disables add, remove, clear, and reorder controls during active `route` requests
- restoration of each control's normal disabled state after the request completes or the DOM rerenders

## Why it changed
Issue #49 identified that rapid route mutations could race because each new request aborted the previous one while the next payload was still built from the current hidden inputs. That made last-write-wins behavior possible for add/remove/reorder actions.

## Impact
Users can no longer stack overlapping route mutations by clicking rapidly. A route change must finish before the next route-mutating action becomes available, which prevents earlier mutations from being silently replaced by a later request built from stale state.

## Root cause
The planner treated route mutations like replacement requests and reused a global abort controller for every request type, while the mutation payload was derived from the current hidden inputs instead of a serialized mutation queue.

## Validation
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh vendor/bin/phpcs -n --standard=phpcs.xml.dist assets/js/plan.js src/Frontend/PlannerRenderer.php`

## Notes
- The unrelated untracked `API-RESILIENCE-ABUSE-REVIEW.md` file was left untouched.