### PR TITLE
Weight planner rate limits by estimated Google work

### DIFF
--- a/plugin/plan-your-day/src/Rest/PlannerRoutes.php
+++ b/plugin/plan-your-day/src/Rest/PlannerRoutes.php
@@ -19,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
 
 final class PlannerRoutes {
 	public const REST_NAMESPACE = 'plan-your-day/v1';
+	private const RATE_LIMIT_BASE_COST = 1;
+	private const BROWSE_SEARCH_COST = 2;
 	private const PUBLIC_TRIP_WAYPOINT_DEADLINE_SECONDS = 12;
 	private const PUBLIC_TRIP_WAYPOINT_PLACE_DETAILS_TIMEOUT = 5;
 	private const PUBLIC_TRIP_WAYPOINT_MAX_FAILURES = 3;
@@ -77,14 +79,15 @@ final class PlannerRoutes {
 				'params' => $this->debug_request_params( $request ),
 			]
 		);
-		$guard = $this->guard_request( $request, 'browse' );
+		$request_state = $this->request_state_parser->parse( $this->request_params_from_request( $request ) );
+		$guard         = $this->guard_request( $request, 'browse', $request_state );
 
 		if ( $guard instanceof WP_Error ) {
 			return $guard;
 		}
 
 		$planner_state = $this->planner_state_builder->build(
-			$this->request_state_parser->parse( $this->request_params_from_request( $request ) ),
+			$request_state,
 			$this->public_trip_waypoint_options( true )
 		);
 		DebugLogger::log(
@@ -114,14 +117,15 @@ final class PlannerRoutes {
 				'params' => $this->debug_request_params( $request ),
 			]
 		);
-		$guard = $this->guard_request( $request, 'route' );
+		$request_state = $this->request_state_parser->parse( $this->request_params_from_request( $request ) );
+		$guard         = $this->guard_request( $request, 'route', $request_state );
 
 		if ( $guard instanceof WP_Error ) {
 			return $guard;
 		}
 
 		$planner_state = $this->planner_state_builder->build(
-			$this->request_state_parser->parse( $this->request_params_from_request( $request ) ),
+			$request_state,
 			$this->public_trip_waypoint_options( false )
 		);
 		DebugLogger::log(
@@ -143,7 +147,7 @@ final class PlannerRoutes {
 		);
 	}
 
-	private function guard_request( WP_REST_Request $request, string $scope ): ?WP_Error {
+	private function guard_request( WP_REST_Request $request, string $scope, array $request_state ): ?WP_Error {
 		if ( ! $this->request_origin_validator->is_same_site_request( $_SERVER ) ) {
 			$error = new WP_Error(
 				'plan_your_day_invalid_origin',
@@ -192,7 +196,7 @@ final class PlannerRoutes {
 			return $error;
 		}
 
-		$rate_limit = $this->rate_limiter->enforce( $scope, $_SERVER );
+		$rate_limit = $this->rate_limiter->enforce( $scope, $_SERVER, $this->get_rate_limit_cost( $scope, $request_state ) );
 
 		if ( $rate_limit instanceof WP_Error ) {
 			DebugLogger::log(
@@ -215,6 +219,22 @@ final class PlannerRoutes {
 			'trip_waypoint_place_details_timeout' => self::PUBLIC_TRIP_WAYPOINT_PLACE_DETAILS_TIMEOUT,
 			'trip_waypoint_max_failures'         => self::PUBLIC_TRIP_WAYPOINT_MAX_FAILURES,
 		];
+	}
+
+	private function get_rate_limit_cost( string $scope, array $request_state ): int {
+		$cost               = self::RATE_LIMIT_BASE_COST;
+		$selected_waypoints = array_values( (array) ( $request_state['selected_waypoint_ids'] ?? [] ) );
+
+		if ( 'browse' === $scope && $this->request_uses_google_search( $request_state ) ) {
+			$cost += self::BROWSE_SEARCH_COST;
+		}
+
+		return $cost + count( $selected_waypoints );
+	}
+
+	private function request_uses_google_search( array $request_state ): bool {
+		return '' !== sanitize_key( (string) ( $request_state['category_key'] ?? '' ) )
+			|| '' !== trim( sanitize_text_field( (string) ( $request_state['category_search'] ?? '' ) ) );
 	}
 
 	private function route_args(): array {

--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -27,9 +27,10 @@ final class RateLimiter {
 		$this->time_provider      = $time_provider ?? static fn (): float => microtime( true );
 	}
 
-	public function enforce( string $scope, array $server = [] ): ?WP_Error {
+	public function enforce( string $scope, array $server = [], int $cost = 1 ): ?WP_Error {
 		$limit = max( 1, $this->settings->get_rate_limit_per_minute() );
 		$ip    = $this->client_ip_resolver->resolve( $server );
+		$cost  = max( 1, $cost );
 
 		if ( '' === $ip ) {
 			$ip = 'unknown';
@@ -53,13 +54,13 @@ final class RateLimiter {
 				)
 			);
 
-			if ( count( $timestamps ) >= $limit ) {
+			if ( count( $timestamps ) + $cost > $limit ) {
 				$this->persist_state( $key, $timestamps );
 
 				return $this->rate_limited_error();
 			}
 
-			$timestamps[] = $now;
+			$timestamps = array_merge( $timestamps, array_fill( 0, $cost, $now ) );
 			$this->persist_state( $key, $timestamps );
 		} finally {
 			$this->release_lock( $key );

--- a/plugin/plan-your-day/tests/PlannerRoutesTest.php
+++ b/plugin/plan-your-day/tests/PlannerRoutesTest.php
@@ -52,4 +52,47 @@ final class PlannerRoutesTest extends TestCase {
 		self::assertTrue( $routes->validate_loose_waypoints( null ) );
 		self::assertFalse( $routes->validate_loose_waypoints( [ 'place-1', [ 'bad' ] ] ) );
 	}
+
+	public function test_get_rate_limit_cost_weights_browse_search_and_trip_waypoints(): void {
+		$routes = ( new ReflectionClass( PlannerRoutes::class ) )->newInstanceWithoutConstructor();
+		$method = new \ReflectionMethod( PlannerRoutes::class, 'get_rate_limit_cost' );
+		$method->setAccessible( true );
+
+		self::assertSame(
+			5,
+			$method->invoke(
+				$routes,
+				'browse',
+				[
+					'category_key'          => 'coffee',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [ 'place-1', 'place-2' ],
+				]
+			)
+		);
+		self::assertSame(
+			3,
+			$method->invoke(
+				$routes,
+				'route',
+				[
+					'category_key'          => 'coffee',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [ 'place-1', 'place-2' ],
+				]
+			)
+		);
+		self::assertSame(
+			1,
+			$method->invoke(
+				$routes,
+				'browse',
+				[
+					'category_key'          => '',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [],
+				]
+			)
+		);
+	}
 }

--- a/plugin/plan-your-day/tests/RateLimiterTest.php
+++ b/plugin/plan-your-day/tests/RateLimiterTest.php
@@ -44,6 +44,18 @@ final class RateLimiterTest extends TestCase {
 		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
 	}
 
+	public function test_enforce_counts_weighted_cost_against_the_limit(): void {
+		$now     = 300.0;
+		$limiter = $this->build_limiter( 5, $now );
+
+		self::assertNull( $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ], 3 ) );
+
+		$error = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ], 3 );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
+	}
+
 	public function test_enforce_recovers_from_a_stale_lock(): void {
 		$now = 200.0;
 		update_option(


### PR DESCRIPTION
## Summary
- weight the rolling REST limiter by estimated external Google API work instead of counting every allowed request as cost `1`
- price `browse` requests for search work plus selected trip waypoint resolution, and price `route` requests for selected trip waypoint resolution
- add PHPUnit coverage for both weighted limiter enforcement and the route-side cost calculation

## Why
The current limiter budgets endpoint requests, but one allowed request can still fan out into multiple Google calls. This change keeps the existing guarded REST path intact while making expensive requests consume more of the per-minute budget before the external work starts.

## Testing
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter 'RateLimiterTest|PlannerRoutesTest'`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh vendor/bin/phpcs -n --standard=phpcs.xml.dist src/Security/RateLimiter.php src/Rest/PlannerRoutes.php tests/RateLimiterTest.php tests/PlannerRoutesTest.php`

Closes #47