### PR TITLE
Update runtime rate limiter settings copy

### DIFF
--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -289,7 +289,7 @@ final class SettingsPage {
 		$this->add_field(
 			'rate_limit_per_minute',
 			__( 'Requests per minute', 'plan-your-day' ),
-			__( 'Configuration value for the later public endpoint rate limiter.', 'plan-your-day' ),
+			__( 'Per-minute budget for the active public planner REST rate limiter. Requests are enforced by client IP and planner scope.', 'plan-your-day' ),
 			'number',
 			[
 				'min' => 1,
@@ -510,7 +510,7 @@ final class SettingsPage {
 	public function render_rate_limiting_section(): void {
 		printf(
 			'<p>%s</p>',
-			esc_html__( 'Store rate-limit configuration for later endpoint enforcement. This issue does not implement the limiter.', 'plan-your-day' )
+			esc_html__( 'Control the active runtime limiter for public planner REST requests. Higher-cost requests can consume more of this budget before external Google work starts.', 'plan-your-day' )
 		);
 	}
 


### PR DESCRIPTION
## Summary
- update the rate-limit field description to say the public planner REST limiter is active today
- update the rate-limiting section copy to describe current runtime enforcement instead of future work

## Why
The admin settings page still described rate limiting as deferred work even though the plugin now enforces it on public planner REST routes. This PR brings the copy back in line with the current runtime behavior.

## Testing
- `./tools/php-runner.sh vendor/bin/phpcs -n --standard=phpcs.xml.dist src/Admin/SettingsPage.php`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`

Closes #51