### PR TITLE
Add plugin REST limiter route coverage

### DIFF
--- a/plugin/plan-your-day/tests/PlannerRoutesTest.php
+++ b/plugin/plan-your-day/tests/PlannerRoutesTest.php
@@ -3,11 +3,37 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Tests;
 
+use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+use Acodebeard\PlanYourDay\Google\GoogleApiResult;
+use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+use Acodebeard\PlanYourDay\Planner\DistanceFormatter;
+use Acodebeard\PlanYourDay\Planner\MapUrlBuilder;
+use Acodebeard\PlanYourDay\Planner\PlannerPayloadBuilder;
+use Acodebeard\PlanYourDay\Planner\PlannerStateBuilder;
+use Acodebeard\PlanYourDay\Planner\RequestStateParser;
+use Acodebeard\PlanYourDay\Planner\StartContextResolver;
+use Acodebeard\PlanYourDay\Planner\WaypointList;
 use Acodebeard\PlanYourDay\Rest\PlannerRoutes;
+use Acodebeard\PlanYourDay\Security\ClientIpResolver;
+use Acodebeard\PlanYourDay\Security\RateLimiter;
+use Acodebeard\PlanYourDay\Security\RequestOriginValidator;
+use Acodebeard\PlanYourDay\Security\VisitorTokenManager;
+use Acodebeard\PlanYourDay\Settings\Settings;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
 
 final class PlannerRoutesTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['plan_your_day_test_options'] = [];
+		$_COOKIE                                = [];
+		$_SERVER                                = [];
+	}
+
 	public function test_sanitize_waypoints_keeps_only_scalar_values_as_strings(): void {
 		$routes = ( new ReflectionClass( PlannerRoutes::class ) )->newInstanceWithoutConstructor();
 
@@ -94,5 +120,118 @@ final class PlannerRoutesTest extends TestCase {
 				]
 			)
 		);
+	}
+
+	public function test_route_rate_limiter_returns_429_after_the_configured_limit(): void {
+		$routes  = $this->build_routes( 1 );
+		$request = $this->build_verified_request( str_repeat( 'ab', 24 ) );
+		$_SERVER = $this->same_site_server( '198.51.100.10' );
+
+		$first  = $routes->route( $request );
+		$second = $routes->route( $request );
+
+		self::assertInstanceOf( WP_REST_Response::class, $first );
+		self::assertInstanceOf( WP_Error::class, $second );
+		self::assertSame( 'plan_your_day_rate_limited', $second->get_error_code() );
+		self::assertSame( 429, $second->get_error_data()['status'] ?? null );
+	}
+
+	public function test_route_rate_limiter_uses_client_ip_even_when_visitor_cookie_changes(): void {
+		$routes = $this->build_routes( 2 );
+		$_SERVER = $this->same_site_server( '198.51.100.10' );
+
+		$first  = $routes->route( $this->build_verified_request( str_repeat( 'ab', 24 ) ) );
+		$second = $routes->route( $this->build_verified_request( str_repeat( 'bc', 24 ) ) );
+		$third  = $routes->route( $this->build_verified_request( str_repeat( 'cd', 24 ) ) );
+
+		self::assertInstanceOf( WP_REST_Response::class, $first );
+		self::assertInstanceOf( WP_REST_Response::class, $second );
+		self::assertInstanceOf( WP_Error::class, $third );
+		self::assertSame( 'plan_your_day_rate_limited', $third->get_error_code() );
+	}
+
+	public function test_route_rate_limiter_uses_trusted_proxy_forwarded_client_ip(): void {
+		$routes  = $this->build_routes( 1, [ 'trusted_proxy_cidrs' => "10.0.0.0/8" ] );
+		$_SERVER = $this->same_site_server(
+			'10.1.1.1',
+			[
+				'HTTP_X_FORWARDED_FOR' => '203.0.113.5, 10.1.1.1',
+			]
+		);
+
+		$first  = $routes->route( $this->build_verified_request( str_repeat( 'ab', 24 ) ) );
+		$second = $routes->route( $this->build_verified_request( str_repeat( 'bc', 24 ) ) );
+
+		self::assertInstanceOf( WP_REST_Response::class, $first );
+		self::assertInstanceOf( WP_Error::class, $second );
+		self::assertSame( 'plan_your_day_rate_limited', $second->get_error_code() );
+	}
+
+	private function build_routes( int $rate_limit_per_minute, array $settings_overrides = [] ): PlannerRoutes {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'rate_limit_per_minute' => $rate_limit_per_minute,
+				],
+				$settings_overrides
+			)
+		);
+
+		$settings = new Settings();
+
+		return new PlannerRoutes(
+			new RequestStateParser( new WaypointList( $settings ) ),
+			new PlannerStateBuilder(
+				$settings,
+				new CategoryCatalog( $settings ),
+				new PlannerRoutesGoogleApiClient(),
+				new WaypointList( $settings ),
+				new StartContextResolver( $settings ),
+				new MapUrlBuilder(),
+				new DistanceFormatter(),
+				new RequestOriginValidator()
+			),
+			new PlannerPayloadBuilder(),
+			new RequestOriginValidator(),
+			new VisitorTokenManager(),
+			new RateLimiter( $settings, new ClientIpResolver( $settings ) )
+		);
+	}
+
+	private function build_verified_request( string $visitor_token ): WP_REST_Request {
+		$_COOKIE['plan_your_day_visitor'] = $visitor_token;
+		$request                          = new WP_REST_Request( 'POST', '/plan-your-day/v1/route' );
+		$request->set_param( 'endpoint_token', hash_hmac( 'sha256', $visitor_token, 'tests-auth|plan-your-day' ) );
+
+		return $request;
+	}
+
+	private function same_site_server( string $remote_addr, array $overrides = [] ): array {
+		return array_merge(
+			[
+				'REMOTE_ADDR'         => $remote_addr,
+				'HTTP_HOST'           => 'example.com',
+				'HTTP_ORIGIN'         => 'https://example.com',
+				'HTTP_REFERER'        => 'https://example.com/planner',
+				'HTTP_SEC_FETCH_SITE' => 'same-origin',
+			],
+			$overrides
+		);
+	}
+}
+
+final class PlannerRoutesGoogleApiClient implements GoogleApiClientInterface {
+	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
+		return GoogleApiResult::success( [ 'places' => [] ] );
+	}
+
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
+		return GoogleApiResult::success( [ 'place' => [] ] );
+	}
+
+	public function geocode( string $address ): GoogleApiResult {
+		return GoogleApiResult::success( [] );
 	}
 }

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -250,4 +250,50 @@ if ( ! class_exists( 'WP_Error' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		private array $params = [];
+
+		public function __construct(
+			private string $method = 'GET',
+			private string $route = ''
+		) {
+		}
+
+		public function get_param( string $key ): mixed {
+			return $this->params[ $key ] ?? null;
+		}
+
+		public function set_param( string $key, mixed $value ): void {
+			$this->params[ $key ] = $value;
+		}
+
+		public function get_method(): string {
+			return $this->method;
+		}
+
+		public function get_route(): string {
+			return $this->route;
+		}
+	}
+}
+
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		public function __construct(
+			private mixed $data = null,
+			private int $status = 200
+		) {
+		}
+
+		public function get_data(): mixed {
+			return $this->data;
+		}
+
+		public function get_status(): int {
+			return $this->status;
+		}
+	}
+}
+
 require dirname( __DIR__ ) . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- add PHPUnit bootstrap doubles for `WP_REST_Request` and `WP_REST_Response` so route-level REST tests can run in the plugin test harness
- extend `PlannerRoutesTest` to hit the real `route()` limiter path instead of only helper methods
- cover 429 after the configured limit, same-IP limiting even when visitor cookies rotate, and trusted-proxy forwarded client resolution

## Why
The existing tests covered limiter helpers, but they did not verify the active plugin REST guard end to end. This PR adds direct route coverage for the current `endpoint_token`-protected limiter path so regressions are caught in the plugin test suite.

## Testing
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist --filter PlannerRoutesTest`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh vendor/bin/phpcs -n --standard=phpcs.xml.dist tests/bootstrap.php tests/PlannerRoutesTest.php`

Closes #50