### PR TITLE
Include request shape in text search cache keys

### DIFF
--- a/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
@@ -36,7 +36,6 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		$parts = [
 			'query'           => trim( sanitize_text_field( $query ) ),
 			'result_count'    => $this->settings->get_result_count(),
-			'distance_unit'   => $this->settings->get_distance_unit(),
 			'rank_preference' => 'DISTANCE',
 			'location_bias'   => null,
 		];

--- a/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
@@ -21,11 +21,7 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
 		$cache_key = $this->cache->build_key(
 			'text_search',
-			[
-				'query'            => trim( sanitize_text_field( $query ) ),
-				'origin_latitude'  => $this->normalize_coordinate( $origin_latitude ),
-				'origin_longitude' => $this->normalize_coordinate( $origin_longitude ),
-			],
+			$this->build_text_search_cache_parts( $query, $origin_latitude, $origin_longitude ),
 			$this->settings->get_google_places_api_key()
 		);
 
@@ -34,6 +30,30 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 			$this->settings->get_google_text_search_cache_ttl(),
 			fn (): GoogleApiResult => $this->client->text_search( $query, $origin_latitude, $origin_longitude )
 		);
+	}
+
+	private function build_text_search_cache_parts( string $query, ?float $origin_latitude, ?float $origin_longitude ): array {
+		$parts = [
+			'query'           => trim( sanitize_text_field( $query ) ),
+			'result_count'    => $this->settings->get_result_count(),
+			'distance_unit'   => $this->settings->get_distance_unit(),
+			'rank_preference' => 'DISTANCE',
+			'location_bias'   => null,
+		];
+
+		if ( $this->is_valid_coordinate( $origin_latitude, -90, 90 ) && $this->is_valid_coordinate( $origin_longitude, -180, 180 ) ) {
+			$parts['location_bias'] = [
+				'circle' => [
+					'center' => [
+						'latitude'  => $this->normalize_coordinate( $origin_latitude ),
+						'longitude' => $this->normalize_coordinate( $origin_longitude ),
+					],
+					'radius' => GoogleApiClient::TEXT_SEARCH_LOCATION_BIAS_RADIUS_METERS,
+				],
+			];
+		}
+
+		return $parts;
 	}
 
 	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
@@ -85,6 +105,10 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 
 	private function normalize_coordinate( ?float $coordinate ): ?string {
 		return null === $coordinate ? null : sprintf( '%.6F', $coordinate );
+	}
+
+	private function is_valid_coordinate( ?float $coordinate, float $minimum, float $maximum ): bool {
+		return null !== $coordinate && $coordinate >= $minimum && $coordinate <= $maximum;
 	}
 
 	private function sanitize_place_id( string $place_id ): string {

--- a/plugin/plan-your-day/src/Google/GoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiClient.php
@@ -15,6 +15,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 	private const GEOCODE_ENDPOINT = 'https://maps.googleapis.com/maps/api/geocode/json';
 	private const TEXT_SEARCH_FIELD_MASK = 'places.id,places.displayName,places.formattedAddress,places.googleMapsUri,places.location';
 	private const PLACE_DETAILS_FIELD_MASK = 'id,displayName,formattedAddress,googleMapsUri';
+	public const TEXT_SEARCH_LOCATION_BIAS_RADIUS_METERS = 15000.0;
 
 	private Settings $settings;
 	private GoogleHttpTransportInterface $transport;
@@ -61,7 +62,7 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 						'latitude'  => $origin_latitude,
 						'longitude' => $origin_longitude,
 					],
-					'radius' => 15000.0,
+					'radius' => self::TEXT_SEARCH_LOCATION_BIAS_RADIUS_METERS,
 				],
 			];
 		}

--- a/plugin/plan-your-day/tests/GoogleApiClientTest.php
+++ b/plugin/plan-your-day/tests/GoogleApiClientTest.php
@@ -50,11 +50,11 @@ final class GoogleApiClientTest extends TestCase {
 	}
 
 	public function test_cached_text_search_key_includes_request_shaping_settings(): void {
-		$cache           = new GoogleApiCache();
+		$cache            = new GoogleApiCache();
 		$recording_client = new RecordingGoogleApiClient();
-		$client          = new CachedGoogleApiClient( $recording_client, new Settings(), $cache );
+		$client           = new CachedGoogleApiClient( $recording_client, new Settings(), $cache );
 
-		$first = $client->text_search( ' Beaches ', 19.6400001, -155.9900001 );
+		$first  = $client->text_search( ' Beaches ', 19.6400001, -155.9900001 );
 		$second = $client->text_search( ' Beaches ', 19.6400001, -155.9900001 );
 
 		self::assertSame( 1, $recording_client->text_search_calls );
@@ -65,7 +65,6 @@ final class GoogleApiClientTest extends TestCase {
 			[
 				'query'           => 'Beaches',
 				'result_count'    => 16,
-				'distance_unit'   => Settings::DISTANCE_UNIT_MILES,
 				'rank_preference' => 'DISTANCE',
 				'location_bias'   => [
 					'circle' => [
@@ -81,6 +80,22 @@ final class GoogleApiClientTest extends TestCase {
 		);
 
 		self::assertArrayHasKey( $expected_cache_key, $GLOBALS['plan_your_day_test_transients'] );
+	}
+
+	public function test_cached_text_search_reuses_cache_when_distance_unit_changes(): void {
+		$recording_client = new RecordingGoogleApiClient();
+		$client           = new CachedGoogleApiClient( $recording_client, new Settings(), new GoogleApiCache() );
+
+		$first = $client->text_search( 'coffee', 19.64, -155.99 );
+
+		$settings                  = $GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ];
+		$settings['distance_unit'] = Settings::DISTANCE_UNIT_KILOMETERS;
+		update_option( Settings::OPTION_NAME, $settings );
+
+		$second = $client->text_search( 'coffee', 19.64, -155.99 );
+
+		self::assertSame( 1, $recording_client->text_search_calls );
+		self::assertSame( $first, $second );
 	}
 
 	public function test_cached_text_search_misses_after_result_count_changes(): void {

--- a/plugin/plan-your-day/tests/GoogleApiClientTest.php
+++ b/plugin/plan-your-day/tests/GoogleApiClientTest.php
@@ -3,7 +3,11 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Tests;
 
+use Acodebeard\PlanYourDay\Google\CachedGoogleApiClient;
 use Acodebeard\PlanYourDay\Google\GoogleApiClient;
+use Acodebeard\PlanYourDay\Google\GoogleApiCache;
+use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+use Acodebeard\PlanYourDay\Google\GoogleApiResult;
 use Acodebeard\PlanYourDay\Google\GoogleHttpTransportInterface;
 use Acodebeard\PlanYourDay\Planner\PlaceParser;
 use Acodebeard\PlanYourDay\Settings\Settings;
@@ -13,11 +17,14 @@ final class GoogleApiClientTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		$GLOBALS['plan_your_day_test_options']    = [];
+		$GLOBALS['plan_your_day_test_transients'] = [];
 		$GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ] = array_merge(
 			Settings::defaults(),
 			[
-				'google_places_api_key' => 'places-key',
-				'google_api_timeout'    => 15,
+				'google_places_api_key'        => 'places-key',
+				'google_api_timeout'           => 15,
+				'google_text_search_cache_ttl' => 600,
 			]
 		);
 	}
@@ -40,6 +47,56 @@ final class GoogleApiClientTest extends TestCase {
 
 		self::assertTrue( $result->is_success() );
 		self::assertSame( 15, $transport->last_get_args['timeout'] ?? null );
+	}
+
+	public function test_cached_text_search_key_includes_request_shaping_settings(): void {
+		$cache           = new GoogleApiCache();
+		$recording_client = new RecordingGoogleApiClient();
+		$client          = new CachedGoogleApiClient( $recording_client, new Settings(), $cache );
+
+		$first = $client->text_search( ' Beaches ', 19.6400001, -155.9900001 );
+		$second = $client->text_search( ' Beaches ', 19.6400001, -155.9900001 );
+
+		self::assertSame( 1, $recording_client->text_search_calls );
+		self::assertSame( $first, $second );
+
+		$expected_cache_key = $cache->build_key(
+			'text_search',
+			[
+				'query'           => 'Beaches',
+				'result_count'    => 16,
+				'distance_unit'   => Settings::DISTANCE_UNIT_MILES,
+				'rank_preference' => 'DISTANCE',
+				'location_bias'   => [
+					'circle' => [
+						'center' => [
+							'latitude'  => '19.640000',
+							'longitude' => '-155.990000',
+						],
+						'radius' => GoogleApiClient::TEXT_SEARCH_LOCATION_BIAS_RADIUS_METERS,
+					],
+				],
+			],
+			'places-key'
+		);
+
+		self::assertArrayHasKey( $expected_cache_key, $GLOBALS['plan_your_day_test_transients'] );
+	}
+
+	public function test_cached_text_search_misses_after_result_count_changes(): void {
+		$recording_client = new RecordingGoogleApiClient();
+		$client           = new CachedGoogleApiClient( $recording_client, new Settings(), new GoogleApiCache() );
+
+		$client->text_search( 'coffee', 19.64, -155.99 );
+		$client->text_search( 'coffee', 19.64, -155.99 );
+
+		$settings = $GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ];
+		$settings['result_count'] = 8;
+		update_option( Settings::OPTION_NAME, $settings );
+
+		$client->text_search( 'coffee', 19.64, -155.99 );
+
+		self::assertSame( 2, $recording_client->text_search_calls );
 	}
 }
 
@@ -73,5 +130,31 @@ final class RecordingGoogleHttpTransport implements GoogleHttpTransportInterface
 			],
 			'body'     => '{}',
 		];
+	}
+}
+
+final class RecordingGoogleApiClient implements GoogleApiClientInterface {
+	public int $text_search_calls = 0;
+
+	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
+		++$this->text_search_calls;
+
+		return GoogleApiResult::success(
+			[
+				'places' => [
+					[
+						'id' => 'call-' . $this->text_search_calls,
+					],
+				],
+			]
+		);
+	}
+
+	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
+		return GoogleApiResult::success( [] );
+	}
+
+	public function geocode( string $address ): GoogleApiResult {
+		return GoogleApiResult::success( [] );
 	}
 }


### PR DESCRIPTION
## Summary
- include result count, distance unit, rank preference, and valid location-bias circle details in cached text-search keys
- share the Google text-search location-bias radius constant between the request body and cache-key construction
- add regression coverage that confirms cached responses are reused for identical request shape and missed after result count changes

## Verification
- `composer lint`
- `composer phpcs`
- `composer phpunit` (35 tests, 114 assertions)

Closes #62