### PR TITLE
Harden trusted proxy CIDR validation

### DIFF
--- a/plugin/plan-your-day/src/Settings/Settings.php
+++ b/plugin/plan-your-day/src/Settings/Settings.php
@@ -321,8 +321,10 @@ final class Settings {
 
 		$parts = explode( '/', $cidr, 2 );
 		$ip    = $parts[0];
+		$ip_bin = inet_pton( $ip );
 
-		if ( false === inet_pton( $ip ) ) {
+		// Zone identifiers are interface-local syntax and should not be used in trusted proxy lists.
+		if ( str_contains( $ip, '%' ) || false === $ip_bin ) {
 			return false;
 		}
 
@@ -335,7 +337,7 @@ final class Settings {
 		}
 
 		$mask_bits = (int) $parts[1];
-		$max_bits  = str_contains( $ip, ':' ) ? 128 : 32;
+		$max_bits  = strlen( $ip_bin ) * 8;
 
 		return $mask_bits >= 0 && $mask_bits <= $max_bits;
 	}

--- a/plugin/plan-your-day/tests/ClientIpResolverTest.php
+++ b/plugin/plan-your-day/tests/ClientIpResolverTest.php
@@ -43,4 +43,46 @@ final class ClientIpResolverTest extends TestCase {
 			)
 		);
 	}
+
+	public function test_returns_last_non_proxy_forwarded_address_when_ipv6_proxy_zero_mask_is_trusted(): void {
+		update_option( Settings::OPTION_NAME, [ 'trusted_proxy_cidrs' => "::/0\n10.0.0.0/8" ] );
+
+		$resolver = new ClientIpResolver( new Settings() );
+
+		self::assertSame(
+			'198.51.100.10',
+			$resolver->resolve(
+				[
+					'REMOTE_ADDR'           => '2001:db8::10',
+					'HTTP_X_FORWARDED_FOR' => '198.51.100.10, 2001:db8::20',
+				]
+			)
+		);
+	}
+
+	public function test_exact_ipv6_host_cidr_only_trusts_the_matching_proxy_address(): void {
+		update_option( Settings::OPTION_NAME, [ 'trusted_proxy_cidrs' => '2001:db8::1/128' ] );
+
+		$resolver = new ClientIpResolver( new Settings() );
+
+		self::assertSame(
+			'198.51.100.10',
+			$resolver->resolve(
+				[
+					'REMOTE_ADDR'           => '2001:db8::1',
+					'HTTP_X_FORWARDED_FOR' => '198.51.100.10',
+				]
+			)
+		);
+
+		self::assertSame(
+			'2001:db8::2',
+			$resolver->resolve(
+				[
+					'REMOTE_ADDR'           => '2001:db8::2',
+					'HTTP_X_FORWARDED_FOR' => '198.51.100.10',
+				]
+			)
+		);
+	}
 }

--- a/plugin/plan-your-day/tests/SettingsTest.php
+++ b/plugin/plan-your-day/tests/SettingsTest.php
@@ -104,4 +104,23 @@ final class SettingsTest extends TestCase {
 
 		self::assertSame( 'places-key', $settings->get_google_geocoding_api_key() );
 	}
+
+	public function test_sanitize_trusted_proxy_cidrs_accepts_ipv4_and_ipv6_edge_masks(): void {
+		$sanitized = Settings::sanitize_trusted_proxy_cidrs(
+			" 0.0.0.0/0,\n192.0.2.10/32\n2001:DB8::/32\n::/0\n2001:db8::1/128\nfe80::/10 "
+		);
+
+		self::assertSame(
+			"0.0.0.0/0\n192.0.2.10/32\n2001:DB8::/32\n::/0\n2001:db8::1/128\nfe80::/10",
+			$sanitized
+		);
+	}
+
+	public function test_sanitize_trusted_proxy_cidrs_rejects_zone_ids_and_invalid_mask_lengths(): void {
+		$sanitized = Settings::sanitize_trusted_proxy_cidrs(
+			"fe80::1%eth0/64\n192.0.2.1/33\n192.0.2.1/128\n2001:db8::/129\n10.0.0.0/8"
+		);
+
+		self::assertSame( '10.0.0.0/8', $sanitized );
+	}
 }


### PR DESCRIPTION
## Summary
- harden trusted proxy CIDR validation by rejecting zone-id forms and deriving valid mask ranges from the parsed IP family
- add sanitizer coverage for IPv4 and IPv6 edge masks plus invalid mask lengths
- expand `ClientIpResolver` tests for trusted IPv6 proxy ranges and exact-host `/128` behavior

## Verification
- `composer lint`
- `composer phpcs`
- `composer phpunit` (41 tests, 129 assertions)

Closes #67