### PR TITLE
Use external object cache for rate limiting

### DIFF
--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -124,17 +124,17 @@ final class RateLimiter {
 	}
 
 	private function acquire_lock( string $key, float $now ): bool {
-		$storage_key = $this->lock_option_name( $key );
+		$option_name = $this->lock_option_name( $key );
 
 		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
-			if ( $this->acquire_lock_for_store( $storage_key, $now ) ) {
+			if ( add_option( $option_name, $now + self::LOCK_TIMEOUT_SECONDS, '', false ) ) {
 				return true;
 			}
 
-			$locked_until = $this->load_lock( $storage_key );
+			$locked_until = get_option( $option_name, 0 );
 
 			if ( is_numeric( $locked_until ) && (float) $locked_until <= $now ) {
-				$this->delete_lock( $storage_key );
+				delete_option( $option_name );
 				continue;
 			}
 
@@ -148,46 +148,15 @@ final class RateLimiter {
 	}
 
 	private function release_lock( string $key ): void {
-		$this->delete_lock( $this->lock_option_name( $key ) );
+		delete_option( $this->lock_option_name( $key ) );
 	}
 
 	private function uses_external_object_cache(): bool {
 		return function_exists( 'wp_using_ext_object_cache' )
 			&& function_exists( 'wp_cache_get' )
 			&& function_exists( 'wp_cache_set' )
-			&& function_exists( 'wp_cache_add' )
 			&& function_exists( 'wp_cache_delete' )
 			&& wp_using_ext_object_cache();
-	}
-
-	private function acquire_lock_for_store( string $storage_key, float $now ): bool {
-		if ( $this->uses_external_object_cache() ) {
-			return wp_cache_add(
-				$storage_key,
-				$now + self::LOCK_TIMEOUT_SECONDS,
-				self::CACHE_GROUP,
-				(int) ceil( self::LOCK_TIMEOUT_SECONDS )
-			);
-		}
-
-		return add_option( $storage_key, $now + self::LOCK_TIMEOUT_SECONDS, '', false );
-	}
-
-	private function load_lock( string $storage_key ): mixed {
-		if ( $this->uses_external_object_cache() ) {
-			return wp_cache_get( $storage_key, self::CACHE_GROUP );
-		}
-
-		return get_option( $storage_key, 0 );
-	}
-
-	private function delete_lock( string $storage_key ): void {
-		if ( $this->uses_external_object_cache() ) {
-			wp_cache_delete( $storage_key, self::CACHE_GROUP );
-			return;
-		}
-
-		delete_option( $storage_key );
 	}
 
 	private function rate_limited_error(): WP_Error {

--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 
 final class RateLimiter {
 	private const WINDOW_SECONDS = 60;
+	private const CACHE_GROUP = 'plan-your-day';
 	private const STATE_OPTION_PREFIX = 'plan_your_day_rate_';
 	private const LOCK_OPTION_PREFIX = 'plan_your_day_rate_lock_';
 	private const LOCK_TIMEOUT_SECONDS = 5.0;
@@ -82,13 +83,19 @@ final class RateLimiter {
 	}
 
 	private function load_state( string $key ): array {
+		if ( $this->uses_external_object_cache() ) {
+			$state = wp_cache_get( $this->state_option_name( $key ), self::CACHE_GROUP );
+
+			return is_array( $state ) ? $state : [];
+		}
+
 		$state = get_option( $this->state_option_name( $key ), [] );
 
 		return is_array( $state ) ? $state : [];
 	}
 
 	private function persist_state( string $key, array $timestamps ): void {
-		$option_name = $this->state_option_name( $key );
+		$storage_key = $this->state_option_name( $key );
 		$timestamps  = array_values(
 			array_map(
 				static function ( mixed $timestamp ): float {
@@ -99,25 +106,35 @@ final class RateLimiter {
 		);
 
 		if ( [] === $timestamps ) {
-			delete_option( $option_name );
+			if ( $this->uses_external_object_cache() ) {
+				wp_cache_delete( $storage_key, self::CACHE_GROUP );
+				return;
+			}
+
+			delete_option( $storage_key );
 			return;
 		}
 
-		update_option( $option_name, $timestamps, false );
+		if ( $this->uses_external_object_cache() ) {
+			wp_cache_set( $storage_key, $timestamps, self::CACHE_GROUP, self::WINDOW_SECONDS );
+			return;
+		}
+
+		update_option( $storage_key, $timestamps, false );
 	}
 
 	private function acquire_lock( string $key, float $now ): bool {
-		$option_name = $this->lock_option_name( $key );
+		$storage_key = $this->lock_option_name( $key );
 
 		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
-			if ( add_option( $option_name, $now + self::LOCK_TIMEOUT_SECONDS, '', false ) ) {
+			if ( $this->acquire_lock_for_store( $storage_key, $now ) ) {
 				return true;
 			}
 
-			$locked_until = get_option( $option_name, 0 );
+			$locked_until = $this->load_lock( $storage_key );
 
 			if ( is_numeric( $locked_until ) && (float) $locked_until <= $now ) {
-				delete_option( $option_name );
+				$this->delete_lock( $storage_key );
 				continue;
 			}
 
@@ -131,7 +148,46 @@ final class RateLimiter {
 	}
 
 	private function release_lock( string $key ): void {
-		delete_option( $this->lock_option_name( $key ) );
+		$this->delete_lock( $this->lock_option_name( $key ) );
+	}
+
+	private function uses_external_object_cache(): bool {
+		return function_exists( 'wp_using_ext_object_cache' )
+			&& function_exists( 'wp_cache_get' )
+			&& function_exists( 'wp_cache_set' )
+			&& function_exists( 'wp_cache_add' )
+			&& function_exists( 'wp_cache_delete' )
+			&& wp_using_ext_object_cache();
+	}
+
+	private function acquire_lock_for_store( string $storage_key, float $now ): bool {
+		if ( $this->uses_external_object_cache() ) {
+			return wp_cache_add(
+				$storage_key,
+				$now + self::LOCK_TIMEOUT_SECONDS,
+				self::CACHE_GROUP,
+				(int) ceil( self::LOCK_TIMEOUT_SECONDS )
+			);
+		}
+
+		return add_option( $storage_key, $now + self::LOCK_TIMEOUT_SECONDS, '', false );
+	}
+
+	private function load_lock( string $storage_key ): mixed {
+		if ( $this->uses_external_object_cache() ) {
+			return wp_cache_get( $storage_key, self::CACHE_GROUP );
+		}
+
+		return get_option( $storage_key, 0 );
+	}
+
+	private function delete_lock( string $storage_key ): void {
+		if ( $this->uses_external_object_cache() ) {
+			wp_cache_delete( $storage_key, self::CACHE_GROUP );
+			return;
+		}
+
+		delete_option( $storage_key );
 	}
 
 	private function rate_limited_error(): WP_Error {

--- a/plugin/plan-your-day/tests/RateLimiterTest.php
+++ b/plugin/plan-your-day/tests/RateLimiterTest.php
@@ -11,7 +11,9 @@ use WP_Error;
 
 final class RateLimiterTest extends TestCase {
 	protected function setUp(): void {
-		$GLOBALS['plan_your_day_test_options'] = [];
+		$GLOBALS['plan_your_day_test_options']      = [];
+		$GLOBALS['plan_your_day_test_object_cache'] = [];
+		$GLOBALS['plan_your_day_use_ext_object_cache'] = false;
 	}
 
 	public function test_enforce_allows_requests_until_the_limit_then_blocks(): void {
@@ -72,6 +74,57 @@ final class RateLimiterTest extends TestCase {
 				'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
 				$GLOBALS['plan_your_day_test_options']
 			)
+		);
+	}
+
+	public function test_enforce_uses_external_object_cache_without_writing_rate_state_options(): void {
+		$GLOBALS['plan_your_day_use_ext_object_cache'] = true;
+
+		$now     = 1000.0;
+		$limiter = $this->build_limiter( 2, $now );
+		$key     = hash( 'sha256', 'browse|198.51.100.10' );
+
+		self::assertNull( $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+		self::assertNull( $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] ) );
+
+		$error = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertArrayHasKey( 'plan-your-day', $GLOBALS['plan_your_day_test_object_cache'] );
+		self::assertArrayHasKey(
+			'plan_your_day_rate_' . $key,
+			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
+		);
+		self::assertArrayNotHasKey(
+			'plan_your_day_rate_lock_' . $key,
+			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
+		);
+		self::assertFalse(
+			array_key_exists(
+				'plan_your_day_rate_' . $key,
+				$GLOBALS['plan_your_day_test_options']
+			)
+		);
+	}
+
+	public function test_enforce_recovers_from_a_stale_external_object_cache_lock(): void {
+		$GLOBALS['plan_your_day_use_ext_object_cache'] = true;
+
+		$now = 200.0;
+		$key = hash( 'sha256', 'browse|198.51.100.10' );
+		$GLOBALS['plan_your_day_test_object_cache']['plan-your-day'][ 'plan_your_day_rate_lock_' . $key ] = 150.0;
+
+		$limiter = $this->build_limiter( 2, $now );
+		$result  = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertNull( $result );
+		self::assertArrayHasKey(
+			'plan_your_day_rate_' . $key,
+			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
+		);
+		self::assertArrayNotHasKey(
+			'plan_your_day_rate_lock_' . $key,
+			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
 		);
 	}
 

--- a/plugin/plan-your-day/tests/RateLimiterTest.php
+++ b/plugin/plan-your-day/tests/RateLimiterTest.php
@@ -111,20 +111,24 @@ final class RateLimiterTest extends TestCase {
 		$GLOBALS['plan_your_day_use_ext_object_cache'] = true;
 
 		$now = 200.0;
-		$key = hash( 'sha256', 'browse|198.51.100.10' );
-		$GLOBALS['plan_your_day_test_object_cache']['plan-your-day'][ 'plan_your_day_rate_lock_' . $key ] = 150.0;
+		update_option(
+			'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
+			150.0
+		);
 
 		$limiter = $this->build_limiter( 2, $now );
 		$result  = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
 
 		self::assertNull( $result );
 		self::assertArrayHasKey(
-			'plan_your_day_rate_' . $key,
+			'plan_your_day_rate_' . hash( 'sha256', 'browse|198.51.100.10' ),
 			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
 		);
-		self::assertArrayNotHasKey(
-			'plan_your_day_rate_lock_' . $key,
-			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
+		self::assertFalse(
+			array_key_exists(
+				'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
+				$GLOBALS['plan_your_day_test_options']
+			)
 		);
 	}
 

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -26,6 +26,8 @@ if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 }
 
 $GLOBALS['plan_your_day_test_options'] = [];
+$GLOBALS['plan_your_day_test_object_cache'] = [];
+$GLOBALS['plan_your_day_use_ext_object_cache'] = false;
 
 if ( ! function_exists( '__' ) ) {
 	function __( string $text, ?string $domain = null ): string {
@@ -128,6 +130,54 @@ if ( ! function_exists( 'add_option' ) ) {
 if ( ! function_exists( 'delete_option' ) ) {
 	function delete_option( string $option_name ): bool {
 		unset( $GLOBALS['plan_your_day_test_options'][ $option_name ] );
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_using_ext_object_cache' ) ) {
+	function wp_using_ext_object_cache(): bool {
+		return ! empty( $GLOBALS['plan_your_day_use_ext_object_cache'] );
+	}
+}
+
+if ( ! function_exists( 'wp_cache_get' ) ) {
+	function wp_cache_get( string $key, string $group = '', bool $force = false, ?bool &$found = null ): mixed {
+		$found = isset( $GLOBALS['plan_your_day_test_object_cache'][ $group ] )
+			&& array_key_exists( $key, $GLOBALS['plan_your_day_test_object_cache'][ $group ] );
+
+		if ( $found ) {
+			return $GLOBALS['plan_your_day_test_object_cache'][ $group ][ $key ];
+		}
+
+		return false;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_set' ) ) {
+	function wp_cache_set( string $key, mixed $value, string $group = '', int $expire = 0 ): bool {
+		$GLOBALS['plan_your_day_test_object_cache'][ $group ][ $key ] = $value;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_add' ) ) {
+	function wp_cache_add( string $key, mixed $value, string $group = '', int $expire = 0 ): bool {
+		if ( isset( $GLOBALS['plan_your_day_test_object_cache'][ $group ] )
+			&& array_key_exists( $key, $GLOBALS['plan_your_day_test_object_cache'][ $group ] ) ) {
+			return false;
+		}
+
+		$GLOBALS['plan_your_day_test_object_cache'][ $group ][ $key ] = $value;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'wp_cache_delete' ) ) {
+	function wp_cache_delete( string $key, string $group = '' ): bool {
+		unset( $GLOBALS['plan_your_day_test_object_cache'][ $group ][ $key ] );
 
 		return true;
 	}


### PR DESCRIPTION
## Summary
- keep the existing `wp_options` rate-limiter store as the fallback path
- use an external object-cache fast path for rate state when WordPress reports a persistent object cache
- keep lock acquisition and release on the option store so cache backend write failures do not degrade into false `429` responses
- add test bootstrap cache stubs and regression coverage for object-cache state plus stale lock recovery

## Verification
- `composer lint`
- `composer phpcs`
- `composer phpunit` (39 tests, 134 assertions)

Closes #66