### PR TITLE
[codex] Memoize sanitized settings reads

### DIFF
--- a/plugin/plan-your-day/src/Settings/Settings.php
+++ b/plugin/plan-your-day/src/Settings/Settings.php
@@ -14,6 +14,13 @@ final class Settings {
 	public const START_MODE_CUSTOM = 'custom';
 	public const DISTANCE_UNIT_MILES = 'miles';
 	public const DISTANCE_UNIT_KILOMETERS = 'kilometers';
+	private ?array $cached_settings = null;
+
+	public function __construct() {
+		add_action( 'update_option_' . self::OPTION_NAME, [ $this, 'flush_cache' ], 10, 0 );
+		add_action( 'add_option_' . self::OPTION_NAME, [ $this, 'flush_cache' ], 10, 0 );
+		add_action( 'delete_option_' . self::OPTION_NAME, [ $this, 'flush_cache' ], 10, 0 );
+	}
 
 	public static function defaults(): array {
 		return [
@@ -343,10 +350,20 @@ final class Settings {
 	}
 
 	public function get_all(): array {
+		if ( null !== $this->cached_settings ) {
+			return $this->cached_settings;
+		}
+
 		$settings = get_option( self::OPTION_NAME, [] );
 		$settings = is_array( $settings ) ? $settings : [];
 
-		return array_merge( self::defaults(), self::sanitize( $settings ) );
+		$this->cached_settings = array_merge( self::defaults(), self::sanitize( $settings ) );
+
+		return $this->cached_settings;
+	}
+
+	public function flush_cache(): void {
+		$this->cached_settings = null;
 	}
 
 	public function get_missing_required_settings(): array {

--- a/plugin/plan-your-day/tests/SettingsTest.php
+++ b/plugin/plan-your-day/tests/SettingsTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 final class SettingsTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['plan_your_day_test_options'] = [];
+		$GLOBALS['plan_your_day_test_actions'] = [];
+		$GLOBALS['plan_your_day_test_option_reads'] = [];
 	}
 
 	public function test_sanitize_normalizes_settings_values(): void {
@@ -122,5 +124,53 @@ final class SettingsTest extends TestCase {
 		);
 
 		self::assertSame( '10.0.0.0/8', $sanitized );
+	}
+
+	public function test_getters_reuse_memoized_settings_for_the_same_request(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'default_location_label'   => 'Harbor Start',
+					'default_location_address' => '123 Main St',
+				]
+			)
+		);
+
+		$settings = new Settings();
+
+		self::assertSame( 'Harbor Start', $settings->get_default_location_label() );
+		self::assertSame( '123 Main St', $settings->get_default_location_address() );
+		self::assertSame( 1, $GLOBALS['plan_your_day_test_option_reads'][ Settings::OPTION_NAME ] ?? 0 );
+	}
+
+	public function test_settings_cache_is_flushed_when_the_option_changes(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'default_location_label' => 'Before',
+				]
+			)
+		);
+
+		$settings = new Settings();
+
+		self::assertSame( 'Before', $settings->get_default_location_label() );
+
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'default_location_label' => 'After',
+				]
+			)
+		);
+
+		self::assertSame( 'After', $settings->get_default_location_label() );
+		self::assertSame( 2, $GLOBALS['plan_your_day_test_option_reads'][ Settings::OPTION_NAME ] ?? 0 );
 	}
 }

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -29,6 +29,8 @@ $GLOBALS['plan_your_day_test_options'] = [];
 $GLOBALS['plan_your_day_test_object_cache'] = [];
 $GLOBALS['plan_your_day_use_ext_object_cache'] = false;
 $GLOBALS['plan_your_day_test_filters'] = [];
+$GLOBALS['plan_your_day_test_actions'] = [];
+$GLOBALS['plan_your_day_test_option_reads'] = [];
 
 if ( ! function_exists( '__' ) ) {
 	function __( string $text, ?string $domain = null ): string {
@@ -104,6 +106,8 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $option_name, mixed $default = false ): mixed {
+		$GLOBALS['plan_your_day_test_option_reads'][ $option_name ] = ( $GLOBALS['plan_your_day_test_option_reads'][ $option_name ] ?? 0 ) + 1;
+
 		return $GLOBALS['plan_your_day_test_options'][ $option_name ] ?? $default;
 	}
 }
@@ -111,6 +115,17 @@ if ( ! function_exists( 'get_option' ) ) {
 if ( ! function_exists( 'add_filter' ) ) {
 	function add_filter( string $hook_name, callable $callback, int $priority = 10 ): bool {
 		$GLOBALS['plan_your_day_test_filters'][ $hook_name ][ $priority ][] = $callback;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( string $hook_name, callable $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		$GLOBALS['plan_your_day_test_actions'][ $hook_name ][ $priority ][] = [
+			'callback'      => $callback,
+			'accepted_args' => $accepted_args,
+		];
 
 		return true;
 	}
@@ -140,9 +155,30 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( string $hook_name, mixed ...$args ): void {
+		if ( ! isset( $GLOBALS['plan_your_day_test_actions'][ $hook_name ] ) ) {
+			return;
+		}
+
+		$callbacks = $GLOBALS['plan_your_day_test_actions'][ $hook_name ];
+		ksort( $callbacks );
+
+		foreach ( $callbacks as $priority_callbacks ) {
+			foreach ( $priority_callbacks as $registration ) {
+				call_user_func_array(
+					$registration['callback'],
+					array_slice( $args, 0, (int) $registration['accepted_args'] )
+				);
+			}
+		}
+	}
+}
+
 if ( ! function_exists( 'update_option' ) ) {
 	function update_option( string $option_name, mixed $value, mixed $autoload = null ): bool {
 		$GLOBALS['plan_your_day_test_options'][ $option_name ] = $value;
+		do_action( 'update_option_' . $option_name, $GLOBALS['plan_your_day_test_options'][ $option_name ] );
 
 		return true;
 	}
@@ -155,6 +191,7 @@ if ( ! function_exists( 'add_option' ) ) {
 		}
 
 		$GLOBALS['plan_your_day_test_options'][ $option_name ] = $value;
+		do_action( 'add_option_' . $option_name, $value );
 
 		return true;
 	}
@@ -163,6 +200,7 @@ if ( ! function_exists( 'add_option' ) ) {
 if ( ! function_exists( 'delete_option' ) ) {
 	function delete_option( string $option_name ): bool {
 		unset( $GLOBALS['plan_your_day_test_options'][ $option_name ] );
+		do_action( 'delete_option_' . $option_name );
 
 		return true;
 	}


### PR DESCRIPTION
## Summary
- memoize the sanitized `plan_your_day_settings` array for the lifetime of a `Settings` instance
- flush the memoized cache when the settings option is added, updated, or deleted in the same request
- add regression coverage proving repeated getters reuse one option read and that updates invalidate the cache

## Why
`Settings::get_all()` currently re-sanitizes the full settings payload on every getter call. The plugin reuses one `Settings` instance across a request, so per-request memoization removes repeated normalization work without changing persisted data.

## Verification
- `composer test`
- rebased onto current `main` and resolved the `tests/bootstrap.php` integration overlap

Closes #65