### PR TITLE
[codex] Add targeted Google API cache clears

### DIFF
--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -343,6 +343,32 @@ final class SettingsPage {
 				<?php wp_nonce_field( 'plan_your_day_clear_google_cache' ); ?>
 				<?php submit_button( __( 'Clear Google API cache', 'plan-your-day' ), 'secondary', 'submit', false ); ?>
 			</form>
+			<h3><?php esc_html_e( 'Targeted Cache Tools', 'plan-your-day' ); ?></h3>
+			<p><?php esc_html_e( 'Clear cached entries for one Google API scope or one place ID without dropping the full cache.', 'plan-your-day' ); ?></p>
+			<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post" style="margin-bottom:1rem;">
+				<input type="hidden" name="action" value="plan_your_day_clear_google_cache_scope" />
+				<?php wp_nonce_field( 'plan_your_day_clear_google_cache_scope' ); ?>
+				<label for="plan-your-day-cache-scope"><strong><?php esc_html_e( 'Cache scope', 'plan-your-day' ); ?></strong></label>
+				<select id="plan-your-day-cache-scope" name="plan_your_day_cache_scope">
+					<?php foreach ( $this->google_cache_scope_choices() as $scope_value => $scope_label ) : ?>
+						<option value="<?php echo esc_attr( $scope_value ); ?>"><?php echo esc_html( $scope_label ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<?php submit_button( __( 'Clear selected scope', 'plan-your-day' ), 'secondary', 'submit', false ); ?>
+			</form>
+			<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+				<input type="hidden" name="action" value="plan_your_day_clear_google_cache_place" />
+				<?php wp_nonce_field( 'plan_your_day_clear_google_cache_place' ); ?>
+				<label for="plan-your-day-cache-place-id"><strong><?php esc_html_e( 'Google Place ID', 'plan-your-day' ); ?></strong></label>
+				<input
+					type="text"
+					id="plan-your-day-cache-place-id"
+					name="plan_your_day_cache_place_id"
+					class="regular-text"
+					placeholder="<?php echo esc_attr__( 'Enter a Google Place ID', 'plan-your-day' ); ?>"
+				/>
+				<?php submit_button( __( 'Clear this place', 'plan-your-day' ), 'secondary', 'submit', false ); ?>
+			</form>
 			<hr />
 			<h2><?php esc_html_e( 'Google API Test', 'plan-your-day' ); ?></h2>
 			<p><?php esc_html_e( 'Run a lightweight admin-only probe using the configured default location, categories, and server-side Google keys.', 'plan-your-day' ); ?></p>
@@ -555,6 +581,50 @@ final class SettingsPage {
 			[
 				'page'                        => Settings::PAGE_SLUG,
 				'plan_your_day_cache_cleared' => $cleared,
+			],
+			admin_url( 'options-general.php' )
+		);
+
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+
+	public function handle_clear_google_cache_scope(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage Plan Your Day settings.', 'plan-your-day' ) );
+		}
+
+		check_admin_referer( 'plan_your_day_clear_google_cache_scope' );
+
+		$scope        = isset( $_POST['plan_your_day_cache_scope'] ) ? sanitize_key( wp_unslash( $_POST['plan_your_day_cache_scope'] ) ) : '';
+		$cleared      = $this->google_api_cache->clear_for_scope( $scope );
+		$redirect_url = add_query_arg(
+			[
+				'page'                              => Settings::PAGE_SLUG,
+				'plan_your_day_cache_scope'         => $scope,
+				'plan_your_day_cache_scope_cleared' => $cleared,
+			],
+			admin_url( 'options-general.php' )
+		);
+
+		wp_safe_redirect( $redirect_url );
+		exit;
+	}
+
+	public function handle_clear_google_cache_place(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage Plan Your Day settings.', 'plan-your-day' ) );
+		}
+
+		check_admin_referer( 'plan_your_day_clear_google_cache_place' );
+
+		$place_id     = isset( $_POST['plan_your_day_cache_place_id'] ) ? sanitize_text_field( wp_unslash( $_POST['plan_your_day_cache_place_id'] ) ) : '';
+		$cleared      = $this->google_api_cache->clear_for_place( $place_id );
+		$redirect_url = add_query_arg(
+			[
+				'page'                              => Settings::PAGE_SLUG,
+				'plan_your_day_cache_place_id'      => $place_id,
+				'plan_your_day_cache_place_cleared' => $cleared,
 			],
 			admin_url( 'options-general.php' )
 		);
@@ -1035,6 +1105,8 @@ final class SettingsPage {
 
 	private function render_cache_notice(): void {
 		if ( ! isset( $_GET['plan_your_day_cache_cleared'] ) ) {
+			$this->render_scope_cache_notice();
+			$this->render_place_cache_notice();
 			return;
 		}
 
@@ -1044,15 +1116,92 @@ final class SettingsPage {
 
 		$cleared = absint( wp_unslash( $_GET['plan_your_day_cache_cleared'] ) );
 
-			printf(
-				'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
-				esc_html(
-					sprintf(
-						/* translators: %d is the number of cleared cache items. */
-						_n( 'Cleared %d Google API cache item.', 'Cleared %d Google API cache items.', $cleared, 'plan-your-day' ),
-						$cleared
-					)
+		printf(
+			'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: %d is the number of cleared cache items. */
+					_n( 'Cleared %d Google API cache item.', 'Cleared %d Google API cache items.', $cleared, 'plan-your-day' ),
+					$cleared
 				)
-			);
+			)
+		);
+
+		$this->render_scope_cache_notice();
+		$this->render_place_cache_notice();
+	}
+
+	private function render_scope_cache_notice(): void {
+		if ( ! isset( $_GET['plan_your_day_cache_scope_cleared'] ) || is_array( $_GET['plan_your_day_cache_scope_cleared'] ) ) {
+			return;
+		}
+
+		$scope = isset( $_GET['plan_your_day_cache_scope'] ) && ! is_array( $_GET['plan_your_day_cache_scope'] )
+			? sanitize_key( wp_unslash( $_GET['plan_your_day_cache_scope'] ) )
+			: '';
+
+		if ( '' === $scope ) {
+			return;
+		}
+
+		$cleared = absint( wp_unslash( $_GET['plan_your_day_cache_scope_cleared'] ) );
+
+		printf(
+			'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: 1: cache scope, 2: number of cleared cache items. */
+					_n(
+						'Cleared %2$d Google API cache item for the %1$s scope.',
+						'Cleared %2$d Google API cache items for the %1$s scope.',
+						$cleared,
+						'plan-your-day'
+					),
+					$scope,
+					$cleared
+				)
+			)
+		);
+	}
+
+	private function render_place_cache_notice(): void {
+		if ( ! isset( $_GET['plan_your_day_cache_place_cleared'] ) || is_array( $_GET['plan_your_day_cache_place_cleared'] ) ) {
+			return;
+		}
+
+		$place_id = isset( $_GET['plan_your_day_cache_place_id'] ) && ! is_array( $_GET['plan_your_day_cache_place_id'] )
+			? sanitize_text_field( wp_unslash( $_GET['plan_your_day_cache_place_id'] ) )
+			: '';
+
+		if ( '' === $place_id ) {
+			return;
+		}
+
+		$cleared = absint( wp_unslash( $_GET['plan_your_day_cache_place_cleared'] ) );
+
+		printf(
+			'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: 1: place ID, 2: number of cleared cache items. */
+					_n(
+						'Cleared %2$d Google API cache item for place ID %1$s.',
+						'Cleared %2$d Google API cache items for place ID %1$s.',
+						$cleared,
+						'plan-your-day'
+					),
+					$place_id,
+					$cleared
+				)
+			)
+		);
+	}
+
+	private function google_cache_scope_choices(): array {
+		return [
+			'text_search'   => __( 'Text search', 'plan-your-day' ),
+			'place_details' => __( 'Place details', 'plan-your-day' ),
+			'geocode'       => __( 'Geocoding', 'plan-your-day' ),
+		];
 	}
 }

--- a/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
@@ -28,6 +28,8 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		return $this->remember(
 			$cache_key,
 			$this->settings->get_google_text_search_cache_ttl(),
+			'text_search',
+			'',
 			fn (): GoogleApiResult => $this->client->text_search( $query, $origin_latitude, $origin_longitude )
 		);
 	}
@@ -67,6 +69,8 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		return $this->remember(
 			$cache_key,
 			$this->settings->get_google_place_details_cache_ttl(),
+			'place_details',
+			$this->sanitize_place_id( $place_id ),
 			fn (): GoogleApiResult => $this->client->place_details( $place_id, $timeout )
 		);
 	}
@@ -83,11 +87,13 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		return $this->remember(
 			$cache_key,
 			$this->settings->get_google_geocoding_cache_ttl(),
+			'geocode',
+			'',
 			fn (): GoogleApiResult => $this->client->geocode( $address )
 		);
 	}
 
-	private function remember( string $cache_key, int $ttl, callable $callback ): GoogleApiResult {
+	private function remember( string $cache_key, int $ttl, string $scope, string $place_id, callable $callback ): GoogleApiResult {
 		if ( $ttl > 0 ) {
 			$cached = $this->cache->get( $cache_key );
 
@@ -97,7 +103,7 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 		}
 
 		$result = $callback();
-		$this->cache->set( $cache_key, $result, $ttl );
+		$this->cache->set( $cache_key, $result, $ttl, $scope, $place_id );
 
 		return $result;
 	}

--- a/plugin/plan-your-day/src/Google/GoogleApiCache.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiCache.php
@@ -31,60 +31,151 @@ final class GoogleApiCache {
 		return $cached instanceof GoogleApiResult ? $cached : null;
 	}
 
-	public function set( string $cache_key, GoogleApiResult $result, int $ttl ): void {
+	public function set( string $cache_key, GoogleApiResult $result, int $ttl, string $scope = '', string $place_id = '' ): void {
 		if ( $ttl < 1 || ! $result->is_success() ) {
 			return;
 		}
 
 		set_transient( $cache_key, $result, $ttl );
-		$this->track_key( $cache_key );
+		$this->track_entry( $cache_key, $scope, $place_id );
 	}
 
 	public function clear(): int {
-		$cache_keys = $this->get_tracked_keys();
-
-		foreach ( $cache_keys as $cache_key ) {
-			delete_transient( $cache_key );
-		}
-
-		delete_option( self::INDEX_OPTION );
-
-		return count( $cache_keys );
+		return $this->clear_matching(
+			static function (): bool {
+				return true;
+			}
+		);
 	}
 
-	private function track_key( string $cache_key ): void {
-		$cache_keys = $this->get_tracked_keys();
-		$cache_keys[] = $cache_key;
-		$cache_keys = array_values( array_unique( $cache_keys ) );
+	public function clear_for_scope( string $scope ): int {
+		$scope = sanitize_key( $scope );
 
-		if ( count( $cache_keys ) > self::MAX_TRACKED_KEYS ) {
-			$cache_keys = array_slice( $cache_keys, -self::MAX_TRACKED_KEYS );
+		if ( '' === $scope ) {
+			return 0;
 		}
 
-		update_option( self::INDEX_OPTION, $cache_keys, false );
+		return $this->clear_matching(
+			static function ( array $entry ) use ( $scope ): bool {
+				return $entry['scope'] === $scope;
+			}
+		);
 	}
 
-	private function get_tracked_keys(): array {
-		$cache_keys = get_option( self::INDEX_OPTION, [] );
+	public function clear_for_place( string $place_id ): int {
+		$place_id = $this->sanitize_place_id( $place_id );
 
-		if ( ! is_array( $cache_keys ) ) {
-			return [];
+		if ( '' === $place_id ) {
+			return 0;
 		}
 
-		$tracked_keys = [];
+		return $this->clear_matching(
+			static function ( array $entry ) use ( $place_id ): bool {
+				return $entry['place_id'] === $place_id;
+			}
+		);
+	}
 
-		foreach ( $cache_keys as $cache_key ) {
-			if ( ! is_scalar( $cache_key ) ) {
+	private function track_entry( string $cache_key, string $scope, string $place_id ): void {
+		$entries           = $this->get_tracked_entries();
+		$entries_by_key    = [];
+
+		foreach ( $entries as $entry ) {
+			$entries_by_key[ $entry['cache_key'] ] = $entry;
+		}
+
+		$entries_by_key[ $cache_key ] = [
+			'cache_key' => $cache_key,
+			'scope'     => sanitize_key( $scope ),
+			'place_id'  => $this->sanitize_place_id( $place_id ),
+		];
+
+		$entries = array_values( $entries_by_key );
+
+		if ( count( $entries ) > self::MAX_TRACKED_KEYS ) {
+			$entries = array_slice( $entries, -self::MAX_TRACKED_KEYS );
+		}
+
+		update_option( self::INDEX_OPTION, $entries, false );
+	}
+
+	private function clear_matching( callable $predicate ): int {
+		$entries         = $this->get_tracked_entries();
+		$remaining       = [];
+		$cleared_count   = 0;
+
+		foreach ( $entries as $entry ) {
+			if ( $predicate( $entry ) ) {
+				delete_transient( $entry['cache_key'] );
+				++$cleared_count;
 				continue;
 			}
 
-			$cache_key = (string) $cache_key;
+			$remaining[] = $entry;
+		}
 
-			if ( str_starts_with( $cache_key, self::KEY_PREFIX ) ) {
-				$tracked_keys[] = $cache_key;
+		if ( [] === $remaining ) {
+			delete_option( self::INDEX_OPTION );
+		} else {
+			update_option( self::INDEX_OPTION, array_values( $remaining ), false );
+		}
+
+		return $cleared_count;
+	}
+
+	private function get_tracked_entries(): array {
+		$entries = get_option( self::INDEX_OPTION, [] );
+
+		if ( ! is_array( $entries ) ) {
+			return [];
+		}
+
+		$tracked_entries = [];
+
+		foreach ( $entries as $entry ) {
+			$normalized = $this->normalize_tracked_entry( $entry );
+
+			if ( null !== $normalized ) {
+				$tracked_entries[ $normalized['cache_key'] ] = $normalized;
 			}
 		}
 
-		return array_values( array_unique( $tracked_keys ) );
+		return array_values( $tracked_entries );
+	}
+
+	private function normalize_tracked_entry( mixed $entry ): ?array {
+		if ( is_scalar( $entry ) ) {
+			$cache_key = (string) $entry;
+
+			if ( ! str_starts_with( $cache_key, self::KEY_PREFIX ) ) {
+				return null;
+			}
+
+			return [
+				'cache_key' => $cache_key,
+				'scope'     => '',
+				'place_id'  => '',
+			];
+		}
+
+		if ( ! is_array( $entry ) ) {
+			return null;
+		}
+
+		$cache_key = is_scalar( $entry['cache_key'] ?? null ) ? (string) $entry['cache_key'] : '';
+
+		if ( ! str_starts_with( $cache_key, self::KEY_PREFIX ) ) {
+			return null;
+		}
+
+		return [
+			'cache_key' => $cache_key,
+			'scope'     => sanitize_key( is_scalar( $entry['scope'] ?? null ) ? (string) $entry['scope'] : '' ),
+			'place_id'  => $this->sanitize_place_id( is_scalar( $entry['place_id'] ?? null ) ? (string) $entry['place_id'] : '' ),
+		];
+	}
+
+	private function sanitize_place_id( string $place_id ): string {
+		return (string) preg_replace( '/[^A-Za-z0-9_-]/', '', trim( $place_id ) );
 	}
 }

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -110,6 +110,8 @@ final class Plugin {
 		add_action( 'admin_menu', [ $this->settings_page, 'register' ] );
 		add_action( 'admin_notices', [ $this->settings_page, 'render_missing_required_settings_notice' ] );
 		add_action( 'admin_post_plan_your_day_clear_google_cache', [ $this->settings_page, 'handle_clear_google_cache' ] );
+		add_action( 'admin_post_plan_your_day_clear_google_cache_scope', [ $this->settings_page, 'handle_clear_google_cache_scope' ] );
+		add_action( 'admin_post_plan_your_day_clear_google_cache_place', [ $this->settings_page, 'handle_clear_google_cache_place' ] );
 		add_action( 'admin_post_plan_your_day_test_google_api', [ $this->settings_page, 'handle_test_google_api' ] );
 	}
 

--- a/plugin/plan-your-day/tests/GoogleApiCacheTest.php
+++ b/plugin/plan-your-day/tests/GoogleApiCacheTest.php
@@ -1,0 +1,51 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Google\GoogleApiCache;
+use Acodebeard\PlanYourDay\Google\GoogleApiResult;
+use PHPUnit\Framework\TestCase;
+
+final class GoogleApiCacheTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['plan_your_day_test_options']    = [];
+		$GLOBALS['plan_your_day_test_transients'] = [];
+	}
+
+	public function test_clear_for_scope_only_removes_matching_entries(): void {
+		$cache  = new GoogleApiCache();
+		$result = GoogleApiResult::success( [ 'ok' => true ] );
+
+		$text_search_key = $cache->build_key( 'text_search', [ 'query' => 'coffee' ], 'places-key' );
+		$place_key       = $cache->build_key( 'place_details', [ 'place_id' => 'place-1' ], 'places-key' );
+		$geocode_key     = $cache->build_key( 'geocode', [ 'address' => '123 Main St' ], 'geocode-key' );
+
+		$cache->set( $text_search_key, $result, 60, 'text_search' );
+		$cache->set( $place_key, $result, 60, 'place_details', 'place-1' );
+		$cache->set( $geocode_key, $result, 60, 'geocode' );
+
+		self::assertSame( 1, $cache->clear_for_scope( 'text_search' ) );
+		self::assertArrayNotHasKey( $text_search_key, $GLOBALS['plan_your_day_test_transients'] );
+		self::assertArrayHasKey( $place_key, $GLOBALS['plan_your_day_test_transients'] );
+		self::assertArrayHasKey( $geocode_key, $GLOBALS['plan_your_day_test_transients'] );
+	}
+
+	public function test_clear_for_place_only_removes_matching_place_details_entries(): void {
+		$cache  = new GoogleApiCache();
+		$result = GoogleApiResult::success( [ 'ok' => true ] );
+
+		$place_one_key = $cache->build_key( 'place_details', [ 'place_id' => 'place-1' ], 'places-key' );
+		$place_two_key = $cache->build_key( 'place_details', [ 'place_id' => 'place-2' ], 'places-key' );
+		$text_key      = $cache->build_key( 'text_search', [ 'query' => 'coffee' ], 'places-key' );
+
+		$cache->set( $place_one_key, $result, 60, 'place_details', 'place-1' );
+		$cache->set( $place_two_key, $result, 60, 'place_details', 'place-2' );
+		$cache->set( $text_key, $result, 60, 'text_search' );
+
+		self::assertSame( 1, $cache->clear_for_place( 'place-1' ) );
+		self::assertArrayNotHasKey( $place_one_key, $GLOBALS['plan_your_day_test_transients'] );
+		self::assertArrayHasKey( $place_two_key, $GLOBALS['plan_your_day_test_transients'] );
+		self::assertArrayHasKey( $text_key, $GLOBALS['plan_your_day_test_transients'] );
+	}
+}


### PR DESCRIPTION
## Summary
- track Google API cache entries with scope and place metadata instead of a flat key list
- add `clear_for_scope()` and `clear_for_place()` selective invalidation paths
- expose admin-only cache tools for clearing one scope or one place ID without nuking the full cache
- add regression coverage for selective cache eviction

## Why
The current cache tooling only supports full-cache clears. When one place or one API scope goes stale, admins should be able to invalidate just that slice and avoid unnecessary cold-cache churn.

## Verification
- `composer test`
- rebased onto current `main`

Closes #64