### PR TITLE
[codex] Restore legacy settings migration

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -68,10 +68,11 @@ The admin settings screen is:
 http://localhost/dkc/wp-admin/options-general.php?page=plan-your-day
 ```
 
-If the legacy DKC theme config is still present, the settings screen now shows a
-`Legacy Migration` panel. Use that tool to copy detected location values, Google
-API keys, and legacy categories into the plugin settings without editing the
-legacy files in place.
+If the target WordPress runtime has legacy planner settings to preserve, define
+`PLAN_YOUR_DAY_LEGACY_CONFIG_FILE` to a PHP file that returns a legacy settings
+array, or provide the same array through the `plan_your_day_legacy_settings`
+filter before activating the plugin. Activation imports those values into the
+plugin settings only when the plugin settings are still effectively empty.
 
 ## Activation Effects
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -70,7 +70,7 @@ Current likely causes:
 The frontend planner is not wired yet, so current Google behavior is mostly
 validated through WP-CLI or future REST/renderer work.
 
-## Plugin Settings Are Empty But Legacy DKC Config Exists
+## Plugin Settings Are Empty But Legacy Planner Settings Exist
 
 Open the plugin settings screen:
 
@@ -78,10 +78,15 @@ Open the plugin settings screen:
 http://localhost/dkc/wp-admin/options-general.php?page=plan-your-day
 ```
 
-If the current WordPress runtime exposes the legacy DKC planner helpers or
-constants, the page shows a `Legacy Migration` panel and an admin notice. Use
-the import action to copy legacy location values, Google API keys, and legacy
-categories into `plan_your_day_settings`.
+If you are upgrading from an earlier standalone planner, expose its settings to
+the plugin before activation. The plugin supports two generic inputs:
+
+- Define `PLAN_YOUR_DAY_LEGACY_CONFIG_FILE` to a PHP file that returns a legacy
+  settings array using plugin setting keys.
+- Or provide the same array through the `plan_your_day_legacy_settings` filter.
+
+Activation imports that legacy data into `plan_your_day_settings` only when the
+plugin settings are still effectively empty.
 
 The importer is conservative:
 

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -19,8 +19,8 @@ registration, admin settings screen, Google API client abstraction, Google API
 caching, and extracted planner helper services.
 
 The public planner frontend, shortcode, block wrapper, REST endpoints, visitor
-token protection, release build process, migration helper, and production QA
-are still in progress.
+token protection, release build process, and production QA are still in
+progress.
 
 == Installation ==
 

--- a/plugin/plan-your-day/src/Activator.php
+++ b/plugin/plan-your-day/src/Activator.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay;
 
+use Acodebeard\PlanYourDay\Admin\LegacyConfigMigrator;
 use Acodebeard\PlanYourDay\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -12,5 +13,7 @@ final class Activator {
 		update_option( 'plan_your_day_version', PLAN_YOUR_DAY_VERSION );
 		update_option( 'plan_your_day_schema_version', PLAN_YOUR_DAY_SCHEMA_VERSION );
 		add_option( Settings::OPTION_NAME, Settings::defaults(), '', false );
+
+		( new LegacyConfigMigrator( new Settings() ) )->import_if_recommended();
 	}
 }

--- a/plugin/plan-your-day/src/Admin/LegacyConfigMigrator.php
+++ b/plugin/plan-your-day/src/Admin/LegacyConfigMigrator.php
@@ -1,0 +1,184 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Admin;
+
+use Acodebeard\PlanYourDay\Settings\Settings;
+
+defined( 'ABSPATH' ) || exit;
+
+final class LegacyConfigMigrator {
+	private Settings $settings;
+
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	public function import_if_recommended(): array {
+		if ( ! $this->migration_is_recommended() ) {
+			return [
+				'imported_fields'     => 0,
+				'imported_categories' => 0,
+			];
+		}
+
+		return $this->import();
+	}
+
+	public function migration_is_recommended(): bool {
+		return $this->has_legacy_config() && $this->plugin_settings_are_effectively_empty();
+	}
+
+	public function has_legacy_config(): bool {
+		$legacy_config = $this->get_legacy_config();
+
+		return '' !== $legacy_config['default_location_label']
+			|| '' !== $legacy_config['default_location_address']
+			|| '' !== $legacy_config['google_maps_embed_api_key']
+			|| '' !== $legacy_config['google_places_api_key']
+			|| '' !== $legacy_config['google_geocoding_api_key']
+			|| [] !== $legacy_config['categories'];
+	}
+
+	public function import(): array {
+		$legacy_config       = $this->get_legacy_config();
+		$current_settings    = $this->settings->get_all();
+		$merged_settings     = $current_settings;
+		$imported_fields     = 0;
+		$imported_categories = 0;
+
+		foreach ( [ 'default_location_label', 'default_location_address', 'default_location_place_id', 'google_maps_embed_api_key', 'google_places_api_key', 'google_geocoding_api_key' ] as $field_key ) {
+			if ( '' === (string) $merged_settings[ $field_key ] && '' !== (string) $legacy_config[ $field_key ] ) {
+				$merged_settings[ $field_key ] = $legacy_config[ $field_key ];
+				++$imported_fields;
+			}
+		}
+
+		foreach ( [ 'default_location_latitude', 'default_location_longitude' ] as $field_key ) {
+			if ( '' === (string) $merged_settings[ $field_key ] && '' !== (string) $legacy_config[ $field_key ] ) {
+				$merged_settings[ $field_key ] = $legacy_config[ $field_key ];
+				++$imported_fields;
+			}
+		}
+
+		if ( [] === (array) $merged_settings['categories'] && [] !== $legacy_config['categories'] ) {
+			$merged_settings['categories'] = $legacy_config['categories'];
+			$imported_categories           = count( $legacy_config['categories'] );
+		}
+
+		if ( [ Settings::START_MODE_DEFAULT, Settings::START_MODE_CUSTOM ] === array_values( (array) $merged_settings['allowed_start_modes'] ) && [] !== $legacy_config['allowed_start_modes'] ) {
+			$merged_settings['allowed_start_modes'] = $legacy_config['allowed_start_modes'];
+			++$imported_fields;
+		}
+
+		update_option( Settings::OPTION_NAME, Settings::sanitize( $merged_settings ) );
+
+		return [
+			'imported_fields'     => $imported_fields,
+			'imported_categories' => $imported_categories,
+		];
+	}
+
+	private function plugin_settings_are_effectively_empty(): bool {
+		$settings = get_option( Settings::OPTION_NAME, [] );
+
+		if ( ! is_array( $settings ) || [] === $settings ) {
+			return true;
+		}
+
+		$settings = Settings::sanitize( $settings );
+
+		return '' === $settings['default_location_label']
+			&& '' === $settings['default_location_address']
+			&& '' === $settings['google_maps_embed_api_key']
+			&& '' === $settings['google_places_api_key']
+			&& '' === $settings['google_geocoding_api_key']
+			&& [] === $settings['categories'];
+	}
+
+	private function get_legacy_config(): array {
+		$legacy_config = $this->load_legacy_config_file();
+
+		if ( function_exists( 'apply_filters' ) ) {
+			$legacy_config = apply_filters( 'plan_your_day_legacy_settings', $legacy_config );
+		}
+
+		if ( ! is_array( $legacy_config ) ) {
+			$legacy_config = [];
+		}
+
+		return [
+			'default_location_label'     => Settings::sanitize_plain_text( $legacy_config['default_location_label'] ?? '' ),
+			'default_location_address'   => Settings::sanitize_plain_textarea( $legacy_config['default_location_address'] ?? '' ),
+			'default_location_latitude'  => Settings::sanitize_coordinate( $legacy_config['default_location_latitude'] ?? '', -90, 90 ),
+			'default_location_longitude' => Settings::sanitize_coordinate( $legacy_config['default_location_longitude'] ?? '', -180, 180 ),
+			'default_location_place_id'  => Settings::sanitize_place_id( $legacy_config['default_location_place_id'] ?? '' ),
+			'allowed_start_modes'        => $this->legacy_allowed_start_modes( $legacy_config['allowed_start_modes'] ?? [] ),
+			'google_maps_embed_api_key'  => Settings::sanitize_api_key( $legacy_config['google_maps_embed_api_key'] ?? '' ),
+			'google_places_api_key'      => Settings::sanitize_api_key( $legacy_config['google_places_api_key'] ?? '' ),
+			'google_geocoding_api_key'   => Settings::sanitize_api_key( $legacy_config['google_geocoding_api_key'] ?? '' ),
+			'categories'                 => $this->legacy_categories( $legacy_config['categories'] ?? [] ),
+		];
+	}
+
+	private function load_legacy_config_file(): array {
+		if ( ! defined( 'PLAN_YOUR_DAY_LEGACY_CONFIG_FILE' ) ) {
+			return [];
+		}
+
+		$config_file = (string) constant( 'PLAN_YOUR_DAY_LEGACY_CONFIG_FILE' );
+
+		if ( '' === $config_file || ! is_readable( $config_file ) ) {
+			return [];
+		}
+
+		if ( ! defined( 'PLAN_YOUR_DAY_LEGACY_BOOTSTRAP' ) ) {
+			define( 'PLAN_YOUR_DAY_LEGACY_BOOTSTRAP', true );
+		}
+
+		$legacy_config = require $config_file;
+
+		return is_array( $legacy_config ) ? $legacy_config : [];
+	}
+
+	private function legacy_allowed_start_modes( array $legacy_modes ): array {
+		$mapped_modes = [];
+
+		foreach ( $legacy_modes as $legacy_mode ) {
+			$mapped_mode = sanitize_key( (string) $legacy_mode );
+
+			if ( in_array( $mapped_mode, array_keys( Settings::start_mode_choices() ), true ) && ! in_array( $mapped_mode, $mapped_modes, true ) ) {
+				$mapped_modes[] = $mapped_mode;
+			}
+		}
+
+		return [] !== $mapped_modes ? $mapped_modes : [ Settings::START_MODE_DEFAULT, Settings::START_MODE_CUSTOM ];
+	}
+
+	private function legacy_categories( array $legacy_categories ): array {
+		$categories = [];
+		$sort_order = 10;
+
+		foreach ( $legacy_categories as $slug => $category ) {
+			if ( ! is_array( $category ) ) {
+				continue;
+			}
+
+			$categories[] = [
+				'slug'        => Settings::sanitize_plain_text(
+					is_string( $slug ) && '' !== $slug
+						? $slug
+						: (string) ( $category['slug'] ?? '' )
+				),
+				'label'       => Settings::sanitize_plain_text( (string) ( $category['label'] ?? '' ) ),
+				'description' => Settings::sanitize_plain_textarea( (string) ( $category['description'] ?? '' ) ),
+				'text_query'  => Settings::sanitize_plain_text( (string) ( $category['text_query'] ?? '' ) ),
+				'enabled'     => true === ( $category['enabled'] ?? true ),
+				'sort_order'  => is_numeric( $category['sort_order'] ?? null ) ? (int) $category['sort_order'] : $sort_order,
+			];
+			$sort_order += 10;
+		}
+
+		return Settings::sanitize_categories( $categories );
+	}
+}

--- a/plugin/plan-your-day/tests/ActivatorTest.php
+++ b/plugin/plan-your-day/tests/ActivatorTest.php
@@ -1,0 +1,133 @@
+<?php
+declare( strict_types=1 );
+
+namespace {
+	function plan_your_day_test_legacy_settings( mixed $legacy_settings ): array {
+		$legacy_settings = is_array( $legacy_settings ) ? $legacy_settings : [];
+		$overrides       = $GLOBALS['plan_your_day_legacy_settings'] ?? [];
+
+		return array_merge( $legacy_settings, is_array( $overrides ) ? $overrides : [] );
+	}
+}
+
+namespace Acodebeard\PlanYourDay\Tests {
+	use Acodebeard\PlanYourDay\Activator;
+	use Acodebeard\PlanYourDay\Settings\Settings;
+	use PHPUnit\Framework\TestCase;
+
+	final class ActivatorTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['plan_your_day_test_options']  = [];
+			$GLOBALS['plan_your_day_test_filters']  = [];
+			$GLOBALS['plan_your_day_legacy_settings'] = [];
+
+			if ( ! defined( 'PLAN_YOUR_DAY_VERSION' ) ) {
+				define( 'PLAN_YOUR_DAY_VERSION', 'test-version' );
+			}
+
+			if ( ! defined( 'PLAN_YOUR_DAY_SCHEMA_VERSION' ) ) {
+				define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 1 );
+			}
+
+			if ( ! defined( 'PLAN_YOUR_DAY_LEGACY_CONFIG_FILE' ) ) {
+				define( 'PLAN_YOUR_DAY_LEGACY_CONFIG_FILE', sys_get_temp_dir() . '/plan-your-day-legacy-config-test.php' );
+			}
+
+			$this->write_legacy_config_file( [] );
+			add_filter( 'plan_your_day_legacy_settings', 'plan_your_day_test_legacy_settings' );
+		}
+
+		public function test_activate_imports_legacy_config_when_plugin_settings_are_empty(): void {
+			$GLOBALS['plan_your_day_legacy_settings'] = [
+				'default_location_label'     => 'Harbor Start',
+				'default_location_address'   => '123 Ocean View Ave',
+				'default_location_latitude'  => '19.639994',
+				'default_location_longitude' => '-155.996933',
+				'default_location_place_id'  => 'ChIJHarborStart',
+				'allowed_start_modes'        => [ 'current', 'default', 'custom' ],
+				'google_maps_embed_api_key'  => 'embed-key_123',
+				'google_places_api_key'      => 'places-key_456',
+				'google_geocoding_api_key'   => 'geocode-key_789',
+				'categories'                 => [
+					[
+						'slug'        => 'beaches',
+						'label'       => 'Beaches',
+						'description' => 'Beach stops',
+						'text_query'  => 'beaches',
+						'enabled'     => true,
+						'sort_order'  => 10,
+					],
+				],
+			];
+
+			Activator::activate();
+
+			$settings = get_option( Settings::OPTION_NAME );
+
+			self::assertSame( 'test-version', get_option( 'plan_your_day_version' ) );
+			self::assertSame( 1, get_option( 'plan_your_day_schema_version' ) );
+			self::assertSame( 'Harbor Start', $settings['default_location_label'] );
+			self::assertSame( '123 Ocean View Ave', $settings['default_location_address'] );
+			self::assertSame( '19.639994', $settings['default_location_latitude'] );
+			self::assertSame( '-155.996933', $settings['default_location_longitude'] );
+			self::assertSame( 'ChIJHarborStart', $settings['default_location_place_id'] );
+			self::assertSame( [ Settings::START_MODE_CURRENT, Settings::START_MODE_DEFAULT, Settings::START_MODE_CUSTOM ], $settings['allowed_start_modes'] );
+			self::assertSame( 'embed-key_123', $settings['google_maps_embed_api_key'] );
+			self::assertSame( 'places-key_456', $settings['google_places_api_key'] );
+			self::assertSame( 'geocode-key_789', $settings['google_geocoding_api_key'] );
+			self::assertSame( 'beaches', $settings['categories'][0]['slug'] ?? null );
+		}
+
+		public function test_activate_does_not_overwrite_existing_plugin_settings(): void {
+			update_option(
+				Settings::OPTION_NAME,
+				array_merge(
+					Settings::defaults(),
+					[
+						'default_location_label'   => 'Existing location',
+						'default_location_address' => 'Existing address',
+					]
+				)
+			);
+
+			$GLOBALS['plan_your_day_legacy_settings'] = [
+				'default_location_label'   => 'Legacy location',
+				'default_location_address' => 'Legacy address',
+			];
+
+			Activator::activate();
+
+			$settings = get_option( Settings::OPTION_NAME );
+
+			self::assertSame( 'Existing location', $settings['default_location_label'] );
+			self::assertSame( 'Existing address', $settings['default_location_address'] );
+		}
+
+		public function test_activate_imports_standalone_config_file_api_keys(): void {
+			$this->write_legacy_config_file(
+				[
+					'google_maps_embed_api_key' => 'config-embed-key',
+					'google_places_api_key'     => 'config-places-key',
+					'google_geocoding_api_key'  => 'config-geocode-key',
+				]
+			);
+
+			Activator::activate();
+
+			$settings = get_option( Settings::OPTION_NAME );
+
+			self::assertSame( 'config-embed-key', $settings['google_maps_embed_api_key'] );
+			self::assertSame( 'config-places-key', $settings['google_places_api_key'] );
+			self::assertSame( 'config-geocode-key', $settings['google_geocoding_api_key'] );
+		}
+
+		private function write_legacy_config_file( array $legacy_settings ): void {
+			file_put_contents(
+				PLAN_YOUR_DAY_LEGACY_CONFIG_FILE,
+				"<?php\n"
+				. "defined( 'PLAN_YOUR_DAY_LEGACY_BOOTSTRAP' ) || exit;\n\n"
+				. 'return ' . var_export( $legacy_settings, true ) . ";\n"
+			);
+		}
+	}
+}

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -28,6 +28,7 @@ if ( ! defined( 'COOKIE_DOMAIN' ) ) {
 $GLOBALS['plan_your_day_test_options'] = [];
 $GLOBALS['plan_your_day_test_object_cache'] = [];
 $GLOBALS['plan_your_day_use_ext_object_cache'] = false;
+$GLOBALS['plan_your_day_test_filters'] = [];
 
 if ( ! function_exists( '__' ) ) {
 	function __( string $text, ?string $domain = null ): string {
@@ -104,6 +105,38 @@ if ( ! function_exists( 'sanitize_title' ) ) {
 if ( ! function_exists( 'get_option' ) ) {
 	function get_option( string $option_name, mixed $default = false ): mixed {
 		return $GLOBALS['plan_your_day_test_options'][ $option_name ] ?? $default;
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( string $hook_name, callable $callback, int $priority = 10 ): bool {
+		$GLOBALS['plan_your_day_test_filters'][ $hook_name ][ $priority ][] = $callback;
+
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $hook_name, mixed $value, mixed ...$args ): mixed {
+		$callbacks_by_priority = $GLOBALS['plan_your_day_test_filters'][ $hook_name ] ?? [];
+
+		if ( ! is_array( $callbacks_by_priority ) ) {
+			return $value;
+		}
+
+		ksort( $callbacks_by_priority );
+
+		foreach ( $callbacks_by_priority as $callbacks ) {
+			if ( ! is_array( $callbacks ) ) {
+				continue;
+			}
+
+			foreach ( $callbacks as $callback ) {
+				$value = $callback( $value, ...$args );
+			}
+		}
+
+		return $value;
 	}
 }
 


### PR DESCRIPTION
## Summary
- restore activation-time legacy settings import through a dedicated `LegacyConfigMigrator`
- keep the plugin generic by consuming legacy data through `PLAN_YOUR_DAY_LEGACY_CONFIG_FILE` or the `plan_your_day_legacy_settings` filter instead of hardcoded DKC symbols
- add regression coverage for activation-time migration and merge the new migration tests with the shared object-cache bootstrap helpers
- update installation and troubleshooting docs to describe the generic legacy-import contract

## Why
Issue #61 is a real upgrade regression, not just a documentation gap. The earlier removal of the migration helper left upgrades from the older standalone planner with empty plugin settings unless values were re-entered by hand.

## Impact
Existing plugin installs are unaffected unless their `plan_your_day_settings` option is still effectively empty. On first activation in that state, the plugin can now import legacy location values, Google API keys, start modes, and categories from an explicit legacy settings source.

## Root Cause
Automatic migration support was removed when the prior legacy helper was deleted, but the plugin still needed a safe path for preserving pre-plugin planner configuration during upgrades.

## Verification
- `composer test` (`46 tests, 156 assertions`)

Closes #61