### PR TITLE
[codex] Genericize install and troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ find plugin/plan-your-day -name '*.php' -print -exec php -l {} \;
 Search for legacy integration-specific strings in plugin code:
 
 ```sh
-rg "localhost/dkc|DKC|dkc|pier" plugin/plan-your-day
+rg "localhost|example\\.test|Kona|pier" plugin/plan-your-day
 ```
 
 No production test suite is wired yet; automated checks are tracked separately.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -35,37 +35,29 @@ Then activate the plugin from the WordPress admin Plugins screen or with WP-CLI:
 wp --path=/path/to/wordpress plugin activate plan-your-day
 ```
 
-## Local DKC Test Install
+## Local Test Install
 
-The current local target test install is:
-
-```text
-/opt/lampp/htdocs/dkc
-```
-
-The local plugin install is a symlink:
+One local development setup can look like this:
 
 ```text
-/opt/lampp/htdocs/dkc/wp-content/plugins/plan-your-day
-  -> /opt/lampp/htdocs/plan-your-day/plugin/plan-your-day
+/path/to/wordpress
+/path/to/wordpress/wp-content/plugins/plan-your-day
+  -> /path/to/plan-your-day/plugin/plan-your-day
 ```
 
 Useful local commands:
 
 ```sh
-sudo /opt/lampp/lampp start
-
-/opt/lampp/bin/php /usr/local/bin/wp \
-  --path=/opt/lampp/htdocs/dkc \
-  --url=http://localhost/dkc \
+wp \
+  --path=/path/to/wordpress \
+  --url=https://example.test \
   plugin status plan-your-day \
-  --allow-root
 ```
 
 The admin settings screen is:
 
 ```text
-http://localhost/dkc/wp-admin/options-general.php?page=plan-your-day
+https://example.test/wp-admin/options-general.php?page=plan-your-day
 ```
 
 If the target WordPress runtime has legacy planner settings to preserve, define

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ progress.
 
 ## Current Documents
 
-- [Installation](INSTALLATION.md): source checkout setup, local DKC install,
+- [Installation](INSTALLATION.md): source checkout setup, local WordPress test install,
   activation checks, and release zip expectations.
 - [Architecture](ARCHITECTURE.md): plugin layers, current service boundaries,
   and what remains in the standalone runtime.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -13,30 +13,28 @@ Release zips should already include `vendor/autoload.php`.
 
 ## WP-CLI Cannot Connect To Database
 
-For XAMPP installs, make sure Apache and MySQL are running:
+Make sure the target WordPress environment and database are actually running.
+For example, on a XAMPP install:
 
 ```sh
 sudo /opt/lampp/lampp start
 ```
 
-Use XAMPP PHP when testing the DKC install:
+If your WP-CLI setup depends on a non-default PHP binary, call that PHP
+explicitly:
 
 ```sh
-/opt/lampp/bin/php /usr/local/bin/wp \
-  --path=/opt/lampp/htdocs/dkc \
-  --url=http://localhost/dkc \
+php /path/to/wp \
+  --path=/path/to/wordpress \
+  --url=https://example.test \
   plugin status plan-your-day \
-  --allow-root
 ```
 
 ## WordPress Says The Site Is Not Installed
 
-The generic `/opt/lampp/htdocs/wordpress` directory may have WordPress files but
-no installed database tables. The current target test site is:
-
-```text
-/opt/lampp/htdocs/dkc
-```
+Your target directory may contain WordPress core files but still have no
+installed database tables. Confirm that the `--path` you pass to WP-CLI points
+to the actual installed site, not just an unpacked WordPress checkout.
 
 ## Settings Page Does Not Appear In A WP-CLI Smoke Test
 
@@ -44,11 +42,10 @@ no installed database tables. The current target test site is:
 WP-CLI, set an administrator user first:
 
 ```sh
-/opt/lampp/bin/php /usr/local/bin/wp \
-  --path=/opt/lampp/htdocs/dkc \
-  --url=http://localhost/dkc \
+php /path/to/wp \
+  --path=/path/to/wordpress \
+  --url=https://example.test \
   eval 'wp_set_current_user(1); do_action("admin_menu"); global $submenu; var_export($submenu["options-general.php"] ?? []);' \
-  --allow-root
 ```
 
 ## Composer Emits Deprecation Notices
@@ -75,7 +72,7 @@ validated through WP-CLI or future REST/renderer work.
 Open the plugin settings screen:
 
 ```text
-http://localhost/dkc/wp-admin/options-general.php?page=plan-your-day
+https://example.test/wp-admin/options-general.php?page=plan-your-day
 ```
 
 If you are upgrading from an earlier standalone planner, expose its settings to


### PR DESCRIPTION
## Summary
- replace hardcoded `localhost` and `/dkc` install examples with generic WordPress paths and URLs
- generalize the installation and troubleshooting guidance so it no longer assumes one local XAMPP target site
- update the docs index and repo README examples to match the generic wording

## Why
The plugin docs still contained environment-specific examples tied to one local deployment. That makes the plugin look more coupled to a specific site than it actually is and creates noise for anyone reading the docs outside that environment.

## Impact
User-facing installation and troubleshooting guidance now describes the plugin in generic WordPress terms. The docs still mention XAMPP as one possible example where useful, but they no longer assume `localhost/dkc` as the default target.

## Verification
- `composer test` (`46 tests, 156 assertions`)