### PR TITLE
[codex] Add editable categories and admin copy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ managed through the WordPress Settings API. Current settings include:
 - Maximum waypoints and result count.
 - Distance unit.
 - Map preview and Google Maps handoff toggles.
+- Editable category buttons with label, description, Google search query,
+  enabled state, and sort order.
 - Browser-facing Maps Embed API key.
 - Server-side Places and Geocoding API keys.
 - Google API timeout and cache TTLs.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,8 +50,21 @@ Settings > Plan Your Day
 ```
 
 The admin screen currently exposes required default location fields, planner
-behavior settings, Google API keys, cache TTLs, rate-limit configuration, trusted
-proxy CIDRs, and a Google API cache clear tool.
+behavior settings, editable planner categories, Google API keys, cache TTLs,
+rate-limit configuration, trusted proxy CIDRs, frontend interface copy
+controls, and a Google API cache clear tool.
+
+Editable frontend copy defaults and field metadata live in:
+
+```text
+plugin/plan-your-day/src/Frontend/InterfaceCopy.php
+```
+
+`Settings` stores those values inside the main option under `interface_copy`,
+and renderer/state classes read them through
+`Settings::get_frontend_copy_value()` and `Settings::format_frontend_copy()`.
+That keeps first-paint HTML, REST responses, and JavaScript runtime strings on
+one source of truth.
 
 ## Google API Layer
 
@@ -82,13 +95,16 @@ Maps Embed key is separate.
 
 Planner helpers extracted so far:
 
-- `CategoryCatalog`: provides generic seed categories until configurable
-  categories land.
+- `CategoryCatalog`: owns the built-in starter category list for fresh installs
+  and empty saved-category fallbacks, then filters the saved category rows down
+  to the enabled frontend catalog.
 - `PlaceParser`: shapes Google place responses and sanitizes Place IDs / HTTPS
   map URLs.
 - `WaypointList`: normalizes, deduplicates, caps, and reorders waypoint IDs.
 - `DistanceFormatter`: calculates straight-line distance hints and formats
   labels in miles or kilometers.
+- `InterfaceCopy`: centralizes editable frontend copy defaults, field metadata,
+  blank/fallback rules, and named-token formatting.
 - `MapUrlBuilder`: builds Google Maps search, directions, and embed URLs.
 - `StartContextResolver`: resolves default/current/custom start behavior using
   plugin settings instead of hardcoded destination defaults.
@@ -100,6 +116,29 @@ Planner helpers extracted so far:
 
 These services are exposed from `Plugin` so the shortcode renderer and REST
 routes share one implementation.
+
+## Category Defaults
+
+Editable categories are stored inside `plan_your_day_settings[categories]`.
+Each row contains:
+
+- `slug`
+- `label`
+- `description`
+- `text_query`
+- `enabled`
+- `sort_order`
+
+Built-in starter rows for fresh installs live in:
+
+```text
+plugin/plan-your-day/src/Planner/CategoryCatalog.php
+```
+
+Use `CategoryCatalog::default_rows()` when changing the starter list for new or
+empty installs. `Settings::get_categories()` resolves the saved rows first and
+falls back to that starter list only when the saved category list is empty and
+the fallback toggle remains enabled.
 
 ## Security Helpers
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -42,6 +42,83 @@ defaults.
 - `map_preview_enabled`: allows future on-page Maps Embed previews.
 - `maps_handoff_enabled`: allows future outbound Google Maps links.
 
+## Categories
+
+Editable categories are stored as:
+
+```text
+plan_your_day_settings[categories]
+```
+
+Each saved category row includes:
+
+- `slug`
+- `label`
+- `description`
+- `text_query`
+- `enabled`
+- `sort_order`
+
+Built-in starter rows for fresh installs and empty-list fallbacks live in:
+
+```text
+plugin/plan-your-day/src/Planner/CategoryCatalog.php
+```
+
+Important behavior:
+
+- `Settings::get_categories()` returns the saved category rows when any exist.
+- If the saved list is empty and `use_preset_categories` remains enabled, the
+  plugin falls back to the built-in starter rows.
+- `CategoryCatalog` filters those rows down to enabled frontend categories and
+  keys them by slug for renderer and planner-state use.
+- `Settings::sanitize_categories()` trims text fields, strips HTML/JS, creates
+  safe unique slugs, drops malformed rows, and sorts by `sort_order`.
+
+To change the starter categories for a fresh install:
+
+1. Update `CategoryCatalog::default_rows()`.
+2. Keep each row generic to the plugin.
+3. Preserve `label`, `description`, `text_query`, `enabled`, and `sort_order`.
+4. Update tests that assert the default/frontend category list.
+
+## Frontend Interface Copy
+
+Frontend interface copy is stored inside the main plugin option as:
+
+```text
+plan_your_day_settings[interface_copy]
+```
+
+Default copy definitions live in:
+
+```text
+plugin/plan-your-day/src/Frontend/InterfaceCopy.php
+```
+
+Important behavior:
+
+- Required labels, buttons, accessible names, and system messages fall back to
+  their default copy when saved blank.
+- Optional helper text and descriptive text can be saved blank to suppress the
+  visible text output.
+- Dynamic copy uses named tokens such as `{count}`, `{search}`, `{place}`,
+  `{start}`, and `{settings}` instead of raw `sprintf()` placeholders.
+- Frontend runtime code receives the same saved/default values through the
+  renderer config JSON, so initial HTML and JavaScript updates stay aligned.
+
+To add a new editable frontend string in the future:
+
+1. Add the string definition to `InterfaceCopy::definitions()` with its default,
+   group, field type, and required/optional rule.
+2. Read it through `Settings::get_frontend_copy_value()` or
+   `Settings::format_frontend_copy()` in the renderer or planner service that
+   outputs the text.
+3. If JavaScript needs the string, add it to the renderer config in
+   `PlannerRenderer::build_config()`.
+4. Add or update tests for fallback, blank handling, and any dynamic token
+   replacement.
+
 ## Google API Keys
 
 - `google_maps_embed_api_key`: browser-facing Maps Embed API key. This key can

--- a/plugin/plan-your-day/assets/css/admin-settings.css
+++ b/plugin/plan-your-day/assets/css/admin-settings.css
@@ -1,0 +1,119 @@
+.plan-your-day-admin-page {
+	scroll-behavior: smooth;
+}
+
+.plan-your-day-admin-accordion {
+	display: grid;
+	gap: 1rem;
+	max-width: 72rem;
+	margin-top: 1rem;
+}
+
+.plan-your-day-admin-accordion__item {
+	margin: 0;
+	border: 1px solid #ccd0d4;
+	border-radius: 12px;
+	background: #fff;
+	box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
+	overflow: hidden;
+}
+
+.plan-your-day-admin-accordion__summary {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 1rem 1.25rem;
+	cursor: pointer;
+	list-style: none;
+}
+
+.plan-your-day-admin-accordion__summary::-webkit-details-marker {
+	display: none;
+}
+
+.plan-your-day-admin-accordion__summary::after {
+	content: "+";
+	flex: 0 0 auto;
+	font-size: 1.5rem;
+	font-weight: 400;
+	line-height: 1;
+	color: #1d2327;
+}
+
+.plan-your-day-admin-accordion__item[open] .plan-your-day-admin-accordion__summary::after {
+	content: "-";
+}
+
+.plan-your-day-admin-accordion__summary-copy {
+	display: grid;
+	gap: 0.35rem;
+}
+
+.plan-your-day-admin-accordion__title {
+	display: block;
+	font-size: 1rem;
+	font-weight: 600;
+	line-height: 1.35;
+	color: #1d2327;
+}
+
+.plan-your-day-admin-accordion__description {
+	display: block;
+	font-size: 0.875rem;
+	line-height: 1.5;
+	color: #50575e;
+}
+
+.plan-your-day-admin-accordion__panel {
+	padding: 0 1.25rem 1.25rem;
+	border-top: 1px solid #e2e4e7;
+}
+
+.plan-your-day-interface-copy-group {
+	display: grid;
+	gap: 1rem;
+	max-width: 56rem;
+	padding-top: 1rem;
+}
+
+.plan-your-day-interface-copy-field-label {
+	display: block;
+	margin-bottom: 0.35rem;
+	font-weight: 600;
+}
+
+.plan-your-day-categories-editor .widefat th:first-child,
+.plan-your-day-categories-editor .widefat td:first-child {
+	padding-left: 1rem;
+}
+
+.plan-your-day-admin-back-to-top {
+	position: fixed;
+	right: 1.5rem;
+	bottom: 1.5rem;
+	z-index: 1000;
+	opacity: 0;
+	transform: translateY(0.75rem);
+	pointer-events: none;
+	transition: opacity 160ms ease, transform 160ms ease;
+}
+
+.plan-your-day-admin-back-to-top.is-visible {
+	opacity: 1;
+	transform: translateY(0);
+	pointer-events: auto;
+}
+
+@media (max-width: 782px) {
+	.plan-your-day-admin-accordion__summary,
+	.plan-your-day-admin-accordion__panel {
+		padding-right: 1rem;
+		padding-left: 1rem;
+	}
+
+	.plan-your-day-admin-back-to-top {
+		right: 1rem;
+		bottom: 1rem;
+	}
+}

--- a/plugin/plan-your-day/assets/js/admin-settings.js
+++ b/plugin/plan-your-day/assets/js/admin-settings.js
@@ -1,0 +1,43 @@
+(() => {
+  const topButton = document.querySelector('[data-plan-back-to-top]');
+  const topTarget = document.getElementById('plan-your-day-settings-top');
+  const topHeading = document.getElementById('plan-your-day-settings-title');
+
+  if (!(topButton instanceof HTMLButtonElement) || !(topTarget instanceof HTMLElement)) {
+    return;
+  }
+
+  const toggleVisibility = () => {
+    const isVisible = window.scrollY > 280;
+
+    topButton.hidden = !isVisible;
+    topButton.classList.toggle('is-visible', isVisible);
+  };
+
+  topButton.addEventListener('click', () => {
+    topTarget.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+
+    if (topHeading instanceof HTMLElement) {
+      window.setTimeout(() => {
+        topHeading.focus({
+          preventScroll: true,
+        });
+      }, 180);
+    }
+  });
+
+  window.addEventListener(
+    'scroll',
+    () => {
+      toggleVisibility();
+    },
+    {
+      passive: true,
+    }
+  );
+
+  toggleVisibility();
+})();

--- a/plugin/plan-your-day/assets/js/plan.js
+++ b/plugin/plan-your-day/assets/js/plan.js
@@ -24,7 +24,15 @@
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#039;');
 
-  const formatString = (template, value) => String(template || '').replace('%s', String(value ?? ''));
+  const formatTemplate = (template, replacements = {}) => {
+    let output = String(template || '');
+
+    Object.entries(replacements || {}).forEach(([key, value]) => {
+      output = output.split(`{${key}}`).join(String(value ?? ''));
+    });
+
+    return output;
+  };
   const redactDebugValue = (value, key = '') => {
     if (Array.isArray(value)) {
       return value.map((item) => redactDebugValue(item));
@@ -167,15 +175,17 @@
                 <div class="plan-your-day__result-tools">
                   ${mapsUri
                     ? `<a class="plan-your-day__result-link" href="${escapeHtml(mapsUri)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(
-                        formatString(strings.viewPlaceInGoogleMapsLabel || '', label)
+                        formatTemplate(strings.viewPlaceInGoogleMapsLabel || '', { place: label })
                       )}">${escapeHtml(strings.viewInGoogleMaps || '')}</a>`
                     : ''}
                   ${isInTrip
-                    ? `<span class="plan-your-day__result-added" aria-label="${escapeHtml(formatString(strings.alreadyInTripAria, label))}">${escapeHtml(strings.inTrip || '')}</span>`
+                    ? `<span class="plan-your-day__result-added" aria-label="${escapeHtml(
+                        formatTemplate(strings.alreadyInTripAria || '', { place: label })
+                      )}">${escapeHtml(strings.inTrip || '')}</span>`
                     : `<button class="plan-your-day__result-add" type="submit" name="waypoints[]" value="${escapeHtml(
                         placeId
                       )}" data-plan-action="add-waypoint" data-plan-route-mutation data-place-id="${escapeHtml(placeId)}" aria-label="${escapeHtml(
-                        formatString(strings.addWaypointLabel || '', label)
+                        formatTemplate(strings.addWaypointLabel || '', { place: label })
                       )}">${escapeHtml(
                         strings.addToTrip || ''
                       )}</button>`}
@@ -244,7 +254,7 @@
                     name="move_waypoint"
                     value="${escapeHtml(`${placeId}:up`)}"
                     data-plan-route-mutation
-                    aria-label="${escapeHtml(formatString(strings.moveWaypointUpLabel || '', label))}"
+                    aria-label="${escapeHtml(formatTemplate(strings.moveWaypointUpLabel || '', { place: label }))}"
                     ${canMoveUp ? '' : 'disabled'}>
                     ${escapeHtml(strings.moveUp || '')}
                   </button>
@@ -254,14 +264,14 @@
                     name="move_waypoint"
                     value="${escapeHtml(`${placeId}:down`)}"
                     data-plan-route-mutation
-                    aria-label="${escapeHtml(formatString(strings.moveWaypointDownLabel || '', label))}"
+                    aria-label="${escapeHtml(formatTemplate(strings.moveWaypointDownLabel || '', { place: label }))}"
                     ${canMoveDown ? '' : 'disabled'}>
                     ${escapeHtml(strings.moveDown || '')}
                   </button>
                   <button type="submit" name="remove_waypoint" value="${escapeHtml(
                     placeId
                   )}" data-plan-action="remove-waypoint" data-plan-route-mutation data-place-id="${escapeHtml(placeId)}">
-                    ${escapeHtml(formatString(strings.removeWaypointLabel, label))}
+                    ${escapeHtml(formatTemplate(strings.removeWaypointLabel || '', { place: label }))}
                   </button>
                 </div>
               </li>
@@ -352,7 +362,7 @@
 
     if (refs.customResultsHeading) {
       refs.customResultsHeading.textContent = hasCustomSearch
-        ? formatString(strings.searchResultsFor || '', browseData.categoryLabel || '')
+        ? formatTemplate(strings.searchResultsFor || '', { search: browseData.categoryLabel || '' })
         : String(browseData?.resultsEmptyState?.heading || '');
     }
 
@@ -393,7 +403,7 @@
     const routeData = state.route || {};
     const iframeSrc = String(routeData.iframeSrc || '');
     const emptyPreviewState = routeData.emptyPreviewState || {};
-    const categoryLabel = String(routeData.categoryLabel || browseData.categoryLabel || 'Not selected');
+    const categoryLabel = String(routeData.categoryLabel || browseData.categoryLabel || strings.notSelected || '');
     const mapsUrl = String(routeData.mapsUrl || '');
 
     renderMessages(refs, routeData.messages);
@@ -846,8 +856,8 @@
             announce(
               refs.liveRegion,
               state.expandedCategory === nextCategory
-                ? formatString(strings.categoryResultsExpanded || '', categoryLabel)
-                : formatString(strings.categoryResultsCollapsed || '', categoryLabel)
+                ? formatTemplate(strings.categoryResultsExpanded || '', { category: categoryLabel })
+                : formatTemplate(strings.categoryResultsCollapsed || '', { category: categoryLabel })
             );
             return;
           }

--- a/plugin/plan-your-day/plan-your-day.php
+++ b/plugin/plan-your-day/plan-your-day.php
@@ -17,7 +17,7 @@ declare( strict_types=1 );
 defined( 'ABSPATH' ) || exit;
 
 define( 'PLAN_YOUR_DAY_VERSION', '0.1.0' );
-define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 1 );
+define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 2 );
 define( 'PLAN_YOUR_DAY_PLUGIN_FILE', __FILE__ );
 define( 'PLAN_YOUR_DAY_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PLAN_YOUR_DAY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/plugin/plan-your-day/src/Activator.php
+++ b/plugin/plan-your-day/src/Activator.php
@@ -10,10 +10,13 @@ defined( 'ABSPATH' ) || exit;
 
 final class Activator {
 	public static function activate(): void {
+		$settings = new Settings();
+
+		add_option( Settings::OPTION_NAME, Settings::defaults(), '', false );
+		( new LegacyConfigMigrator( $settings ) )->import_if_recommended();
+		$settings->seed_default_categories_if_needed();
+
 		update_option( 'plan_your_day_version', PLAN_YOUR_DAY_VERSION );
 		update_option( 'plan_your_day_schema_version', PLAN_YOUR_DAY_SCHEMA_VERSION );
-		add_option( Settings::OPTION_NAME, Settings::defaults(), '', false );
-
-		( new LegacyConfigMigrator( new Settings() ) )->import_if_recommended();
 	}
 }

--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Admin;
 
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
 use Acodebeard\PlanYourDay\Google\GoogleApiCache;
 use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
 use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
@@ -173,6 +174,13 @@ final class SettingsPage {
 		);
 
 		add_settings_section(
+			'plan_your_day_interface_copy',
+			__( 'Interface Copy', 'plan-your-day' ),
+			[ $this, 'render_interface_copy_section' ],
+			Settings::PAGE_SLUG
+		);
+
+		add_settings_section(
 			'plan_your_day_categories',
 			__( 'Categories', 'plan-your-day' ),
 			[ $this, 'render_categories_section' ],
@@ -181,8 +189,8 @@ final class SettingsPage {
 
 		$this->add_field(
 			'use_preset_categories',
-			__( 'Preset category fallback', 'plan-your-day' ),
-			__( 'When no enabled custom categories are saved, show the built-in preset categories. Disable this to display no preset categories.', 'plan-your-day' ),
+			__( 'Starter category fallback', 'plan-your-day' ),
+			__( 'When the saved category list is empty, show the built-in starter categories instead of no category buttons.', 'plan-your-day' ),
 			'checkbox',
 			[],
 			'plan_your_day_categories'
@@ -190,8 +198,8 @@ final class SettingsPage {
 
 		$this->add_field(
 			'categories',
-			__( 'Custom categories', 'plan-your-day' ),
-			__( 'Manage the category list shown to visitors. The Google search query is the phrase sent to Google Places.', 'plan-your-day' ),
+			__( 'Categories', 'plan-your-day' ),
+			__( 'Manage the category buttons shown to visitors. The Google search query is the phrase sent to Google Places.', 'plan-your-day' ),
 			'categories',
 			[],
 			'plan_your_day_categories'
@@ -323,8 +331,8 @@ final class SettingsPage {
 		}
 
 		?>
-		<div class="wrap">
-			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		<div class="wrap plan-your-day-admin-page" id="plan-your-day-settings-top">
+			<h1 id="plan-your-day-settings-title" tabindex="-1"><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php $this->render_cache_notice(); ?>
 			<?php $this->render_google_test_notice(); ?>
 			<?php $this->render_setup_status_panel(); ?>
@@ -378,8 +386,35 @@ final class SettingsPage {
 				<?php submit_button( __( 'Run Google API test', 'plan-your-day' ), 'secondary', 'submit', false ); ?>
 			</form>
 			<?php $this->render_google_test_results_panel(); ?>
+			<button type="button" class="button button-secondary plan-your-day-admin-back-to-top" data-plan-back-to-top hidden>
+				<?php esc_html_e( 'Back to top', 'plan-your-day' ); ?>
+			</button>
 		</div>
 		<?php
+	}
+
+	public function enqueue_assets( string $hook_suffix ): void {
+		if ( ! $this->is_settings_screen( $hook_suffix ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'plan-your-day-admin-settings',
+			PLAN_YOUR_DAY_PLUGIN_URL . 'assets/css/admin-settings.css',
+			[],
+			PLAN_YOUR_DAY_VERSION
+		);
+
+		wp_enqueue_script(
+			'plan-your-day-admin-settings',
+			PLAN_YOUR_DAY_PLUGIN_URL . 'assets/js/admin-settings.js',
+			[],
+			PLAN_YOUR_DAY_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
 	}
 
 	private function render_setup_status_panel(): void {
@@ -436,7 +471,7 @@ final class SettingsPage {
 	}
 
 	private function build_setup_status_checks(): array {
-		$custom_categories = $this->settings->get_categories();
+		$saved_categories  = $this->settings->get_saved_categories();
 		$active_categories = $this->category_catalog->get_all();
 		$missing_required  = $this->settings->get_missing_required_settings();
 		$embed_key         = $this->settings->get_google_maps_embed_api_key();
@@ -487,12 +522,12 @@ final class SettingsPage {
 				'status' => [] !== $active_categories ? __( 'Ready', 'plan-your-day' ) : __( 'Needs setup', 'plan-your-day' ),
 				'detail' => [] !== $active_categories
 					? sprintf(
-						/* translators: 1: active category count, 2: custom category count. */
-						__( '%1$d active categories are available. %2$d custom categories are saved.', 'plan-your-day' ),
+						/* translators: 1: active category count, 2: saved category count. */
+						__( '%1$d active categories are available. %2$d categories are saved in settings.', 'plan-your-day' ),
 						count( $active_categories ),
-						count( $custom_categories )
+						count( $saved_categories )
 					)
-					: __( 'No active categories are available. Add at least one custom category or re-enable the preset fallback.', 'plan-your-day' ),
+					: __( 'No active categories are available. Add at least one category or re-enable the starter category fallback.', 'plan-your-day' ),
 				'type'   => [] !== $active_categories ? 'success' : 'warning',
 			],
 		];
@@ -519,10 +554,19 @@ final class SettingsPage {
 		);
 	}
 
+	public function render_interface_copy_section(): void {
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'Edit the public planner copy here. Button labels and accessible labels fall back to defaults if saved blank. Optional helper text fields can be saved blank to hide them. Dynamic tokens such as {count}, {search}, {place}, and {start} are replaced automatically.', 'plan-your-day' )
+		);
+
+		$this->render_interface_copy_accordion();
+	}
+
 	public function render_categories_section(): void {
 		printf(
 			'<p>%s</p>',
-			esc_html__( 'Use custom categories to replace the temporary built-in set. Disable the preset fallback if you want the public planner to show no preset categories until custom ones are saved.', 'plan-your-day' )
+			esc_html__( 'Edit the category buttons shown on the public planner. You can add, disable, remove, and reorder rows here. Fresh installs start from the built-in starter list, and the fallback toggle only applies when the saved list is empty.', 'plan-your-day' )
 		);
 	}
 
@@ -904,6 +948,8 @@ final class SettingsPage {
 			$this->render_select( $name, $id, (string) $value, $attributes );
 		} elseif ( 'categories' === $type ) {
 			$this->render_categories_editor( $name );
+		} elseif ( 'interface_copy_group' === $type ) {
+			$this->render_interface_copy_group( (string) ( $attributes['group'] ?? '' ) );
 		} else {
 			printf(
 				'<input id="%1$s" name="%2$s" type="%3$s" value="%4$s" class="regular-text" autocomplete="off" spellcheck="false" />',
@@ -919,10 +965,99 @@ final class SettingsPage {
 		}
 	}
 
+	private function render_interface_copy_group( string $group ): void {
+		$definitions = InterfaceCopy::definitions_for_group( $group );
+		$copy        = $this->settings->get_frontend_copy();
+
+		if ( [] === $definitions ) {
+			return;
+		}
+		?>
+		<div class="plan-your-day-interface-copy-group">
+			<?php foreach ( $definitions as $key => $definition ) : ?>
+				<?php
+				$id          = 'plan_your_day_interface_copy_' . $key;
+				$name        = Settings::OPTION_NAME . '[interface_copy][' . $key . ']';
+				$value       = $copy[ $key ] ?? '';
+				$type        = (string) $definition['type'];
+				$description = (string) $definition['description'];
+				?>
+				<div>
+					<label for="<?php echo esc_attr( $id ); ?>" class="plan-your-day-interface-copy-field-label">
+						<?php echo esc_html( (string) $definition['label'] ); ?>
+					</label>
+					<?php if ( 'textarea' === $type ) : ?>
+						<textarea
+							id="<?php echo esc_attr( $id ); ?>"
+							name="<?php echo esc_attr( $name ); ?>"
+							rows="<?php echo esc_attr( (string) ( $definition['rows'] ?? 3 ) ); ?>"
+							class="large-text"
+						><?php echo esc_textarea( (string) $value ); ?></textarea>
+					<?php else : ?>
+						<input
+							id="<?php echo esc_attr( $id ); ?>"
+							name="<?php echo esc_attr( $name ); ?>"
+							type="text"
+							value="<?php echo esc_attr( (string) $value ); ?>"
+							class="regular-text"
+							autocomplete="off"
+							spellcheck="true"
+						/>
+					<?php endif; ?>
+					<?php if ( '' !== $description ) : ?>
+						<p class="description"><?php echo esc_html( $description ); ?></p>
+					<?php endif; ?>
+				</div>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	}
+
+	private function render_interface_copy_accordion(): void {
+		$groups = InterfaceCopy::groups();
+
+		if ( [] === $groups ) {
+			return;
+		}
+		?>
+		<div class="plan-your-day-admin-accordion">
+			<?php $is_first_group = true; ?>
+			<?php foreach ( $groups as $group_key => $group ) : ?>
+				<details class="plan-your-day-admin-accordion__item"<?php echo $is_first_group ? ' open' : ''; ?>>
+					<summary class="plan-your-day-admin-accordion__summary">
+						<span class="plan-your-day-admin-accordion__summary-copy">
+							<span class="plan-your-day-admin-accordion__title"><?php echo esc_html( (string) $group['label'] ); ?></span>
+							<?php if ( '' !== (string) $group['description'] ) : ?>
+								<span class="plan-your-day-admin-accordion__description"><?php echo esc_html( (string) $group['description'] ); ?></span>
+							<?php endif; ?>
+						</span>
+					</summary>
+					<div class="plan-your-day-admin-accordion__panel">
+						<?php $this->render_interface_copy_group( $group_key ); ?>
+					</div>
+				</details>
+				<?php $is_first_group = false; ?>
+			<?php endforeach; ?>
+		</div>
+		<?php
+	}
+
+	private function is_settings_screen( string $hook_suffix ): bool {
+		if ( 'settings_page_' . Settings::PAGE_SLUG === $hook_suffix ) {
+			return true;
+		}
+
+		$page = isset( $_GET['page'] ) && ! is_array( $_GET['page'] )
+			? sanitize_key( wp_unslash( $_GET['page'] ) )
+			: '';
+
+		return Settings::PAGE_SLUG === $page;
+	}
+
 	private function render_categories_editor( string $name ): void {
 		$categories  = $this->settings->get_categories();
 		$row_index   = 0;
-		$seed_rows   = CategoryCatalog::preset_rows();
+		$seed_rows   = CategoryCatalog::default_rows();
 		$next_sort   = ( count( $categories ) + 1 ) * 10;
 		?>
 		<div class="plan-your-day-categories-editor" data-plan-category-editor>
@@ -961,10 +1096,10 @@ final class SettingsPage {
 				<button type="button" class="button" data-plan-add-category><?php esc_html_e( 'Add category', 'plan-your-day' ); ?></button>
 			</p>
 			<p class="description">
-				<?php esc_html_e( 'Leave a row empty to ignore it. Use the sort number to control the public order. Built-in presets remain available only through the fallback toggle above.', 'plan-your-day' ); ?>
+				<?php esc_html_e( 'Leave a row empty to ignore it. Use Enabled to hide a category without deleting it, Remove to delete it on save, and Sort to control the public order. The starter category fallback above is only used when this saved list is empty.', 'plan-your-day' ); ?>
 			</p>
 			<details>
-				<summary><?php esc_html_e( 'View built-in preset categories', 'plan-your-day' ); ?></summary>
+				<summary><?php esc_html_e( 'View built-in starter categories', 'plan-your-day' ); ?></summary>
 				<ul>
 					<?php foreach ( $seed_rows as $seed_row ) : ?>
 						<li>

--- a/plugin/plan-your-day/src/Frontend/InitialPlannerHydration.php
+++ b/plugin/plan-your-day/src/Frontend/InitialPlannerHydration.php
@@ -30,7 +30,8 @@ final class InitialPlannerHydration {
 		return '' !== $category_key || '' !== $category_search || [] !== $selected_waypoints;
 	}
 
-	public static function apply_loading_placeholders( array $planner_state ): array {
+	public static function apply_loading_placeholders( array $planner_state, array $copy = [] ): array {
+		$copy                   = InterfaceCopy::resolve_values( $copy );
 		$has_search             = ! empty( $planner_state['has_search'] );
 		$has_selected_waypoints = [] !== array_filter(
 			array_map(
@@ -44,40 +45,40 @@ final class InitialPlannerHydration {
 
 		$messages[] = [
 			'type' => 'note',
-			'text' => __( 'Loading planner state through a verified request.', 'plan-your-day' ),
+			'text' => $copy['hydration_loading_message'],
 		];
 
 		$planner_state['messages'] = $messages;
 
 		if ( $has_search ) {
-			$planner_state['search_results_label'] = __( 'Loading Google results...', 'plan-your-day' );
+			$planner_state['search_results_label'] = $copy['loading_results_label'];
 			$planner_state['results_empty_state']  = [
-				'heading' => __( 'Loading Google results', 'plan-your-day' ),
-				'body'    => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+				'heading' => $copy['loading_results_heading'],
+				'body'    => $copy['loading_results_body'],
 			];
-			$planner_state['overview']             = __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' );
+			$planner_state['overview']             = $copy['loading_results_body'];
 		}
 
 		if ( $has_selected_waypoints ) {
-			$planner_state['trip_count_label'] = __( 'Loading trip waypoints...', 'plan-your-day' );
+			$planner_state['trip_count_label'] = $copy['loading_trip_count'];
 			$planner_state['trip_empty_state'] = [
-				'heading' => __( 'Loading trip waypoints', 'plan-your-day' ),
-				'body'    => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+				'heading' => $copy['loading_trip_heading'],
+				'body'    => $copy['loading_trip_body'],
 			];
-			$planner_state['overview']         = __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' );
+			$planner_state['overview']         = $copy['loading_trip_body'];
 		}
 
 		if ( $has_selected_waypoints ) {
-			$planner_state['preview_mode_label']  = __( 'Loading trip preview', 'plan-your-day' );
+			$planner_state['preview_mode_label']  = $copy['loading_trip_preview_mode'];
 			$planner_state['preview_empty_state'] = [
-				'heading' => __( 'Loading trip preview', 'plan-your-day' ),
-				'body'    => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+				'heading' => $copy['loading_trip_preview_heading'],
+				'body'    => $copy['loading_trip_preview_body'],
 			];
 		} elseif ( $has_search ) {
-			$planner_state['preview_mode_label']  = __( 'Loading search preview', 'plan-your-day' );
+			$planner_state['preview_mode_label']  = $copy['loading_search_preview_mode'];
 			$planner_state['preview_empty_state'] = [
-				'heading' => __( 'Loading search preview', 'plan-your-day' ),
-				'body'    => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+				'heading' => $copy['loading_search_preview_heading'],
+				'body'    => $copy['loading_search_preview_body'],
 			];
 		}
 

--- a/plugin/plan-your-day/src/Frontend/InterfaceCopy.php
+++ b/plugin/plan-your-day/src/Frontend/InterfaceCopy.php
@@ -1,0 +1,1319 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Frontend;
+
+defined( 'ABSPATH' ) || exit;
+
+final class InterfaceCopy {
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	public static function definitions(): array {
+		return array_merge(
+			self::general_definitions(),
+			self::starting_point_definitions(),
+			self::search_results_definitions(),
+			self::trip_definitions(),
+			self::preview_definitions(),
+			self::status_definitions(),
+			self::distance_definitions()
+		);
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string}>
+	 */
+	public static function groups(): array {
+		return [
+			'general'         => [
+				'label'       => __( 'Top Section And Setup Notice', 'plan-your-day' ),
+				'description' => __( 'Edit the main heading, intro text, and the fallback notice shown when required planner settings are missing.', 'plan-your-day' ),
+			],
+			'starting_point'  => [
+				'label'       => __( 'Starting Point', 'plan-your-day' ),
+				'description' => __( 'Edit the starting-point labels, helper copy, and custom start instructions. Helper text fields may be left blank to hide them.', 'plan-your-day' ),
+			],
+			'search_results'  => [
+				'label'       => __( 'Search And Results', 'plan-your-day' ),
+				'description' => __( 'Edit category search labels, result actions, and search-related empty states.', 'plan-your-day' ),
+			],
+			'trip'            => [
+				'label'       => __( 'Trip Builder', 'plan-your-day' ),
+				'description' => __( 'Edit waypoint labels, empty states, route summaries, and trip-related warnings.', 'plan-your-day' ),
+			],
+			'preview'         => [
+				'label'       => __( 'Preview And Summary', 'plan-your-day' ),
+				'description' => __( 'Edit the preview card, Google Maps handoff labels, and summary field names. Optional helper text may be blank.', 'plan-your-day' ),
+			],
+			'status_messages' => [
+				'label'       => __( 'Loading, Errors, And Live Announcements', 'plan-your-day' ),
+				'description' => __( 'Edit loading text, frontend error messages, and screen-reader announcements triggered by dynamic planner updates.', 'plan-your-day' ),
+			],
+			'distance'        => [
+				'label'       => __( 'Distance Labels', 'plan-your-day' ),
+				'description' => __( 'Edit the distance text shown on search results. Use {distance}, {unit}, and {start} where needed.', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	public static function definitions_for_group( string $group ): array {
+		$definitions = [];
+
+		foreach ( self::definitions() as $key => $definition ) {
+			if ( $definition['group'] === $group ) {
+				$definitions[ $key ] = $definition;
+			}
+		}
+
+		return $definitions;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public static function defaults(): array {
+		$defaults = [];
+
+		foreach ( self::definitions() as $key => $definition ) {
+			$defaults[ $key ] = $definition['default'];
+		}
+
+		return $defaults;
+	}
+
+	public static function default_value( string $key ): string {
+		$definitions = self::definitions();
+
+		return isset( $definitions[ $key ]['default'] ) ? (string) $definitions[ $key ]['default'] : '';
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public static function sanitize( mixed $raw_copy ): array {
+		$definitions = self::definitions();
+		$raw_copy    = is_array( $raw_copy ) ? wp_unslash( $raw_copy ) : [];
+		$sanitized   = [];
+
+		foreach ( $definitions as $key => $definition ) {
+			$has_raw_value = array_key_exists( $key, $raw_copy );
+			$raw_value     = $has_raw_value ? $raw_copy[ $key ] : $definition['default'];
+			$value         = self::sanitize_field_value( $raw_value, $definition['type'] );
+
+			if ( ! $has_raw_value ) {
+				$sanitized[ $key ] = $definition['default'];
+				continue;
+			}
+
+			if ( '' === $value && $definition['required'] ) {
+				$sanitized[ $key ] = $definition['default'];
+				continue;
+			}
+
+			$sanitized[ $key ] = $value;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public static function resolve_values( mixed $copy ): array {
+		$definitions = self::definitions();
+		$copy        = is_array( $copy ) ? $copy : [];
+		$resolved    = [];
+
+		foreach ( $definitions as $key => $definition ) {
+			if ( ! array_key_exists( $key, $copy ) ) {
+				$resolved[ $key ] = $definition['default'];
+				continue;
+			}
+
+			$value = is_scalar( $copy[ $key ] ) ? trim( (string) $copy[ $key ] ) : '';
+
+			if ( '' === $value && $definition['required'] ) {
+				$resolved[ $key ] = $definition['default'];
+				continue;
+			}
+
+			$resolved[ $key ] = $value;
+		}
+
+		return $resolved;
+	}
+
+	public static function format( string $template, array $tokens = [] ): string {
+		if ( [] === $tokens ) {
+			return $template;
+		}
+
+		$replacements = [];
+
+		foreach ( $tokens as $token => $value ) {
+			$replacements[ '{' . trim( (string) $token, '{}' ) . '}' ] = is_scalar( $value ) ? (string) $value : '';
+		}
+
+		return strtr( $template, $replacements );
+	}
+
+	private static function sanitize_field_value( mixed $value, string $type ): string {
+		$value = self::scalar_to_string( $value );
+
+		return 'textarea' === $type
+			? trim( sanitize_textarea_field( $value ) )
+			: trim( sanitize_text_field( $value ) );
+	}
+
+	private static function scalar_to_string( mixed $value ): string {
+		if ( is_bool( $value ) ) {
+			return $value ? '1' : '0';
+		}
+
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function general_definitions(): array {
+		return [
+			'setup_notice_title'     => [
+				'label'       => __( 'Setup notice heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'general',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Plan Your Day setup needed', 'plan-your-day' ),
+			],
+			'setup_notice_body'      => [
+				'label'       => __( 'Setup notice message', 'plan-your-day' ),
+				'description' => __( 'Use {settings} where the missing setting list should appear.', 'plan-your-day' ),
+				'group'       => 'general',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner needs required settings before it can render: {settings}.', 'plan-your-day' ),
+			],
+			'setup_notice_link'      => [
+				'label'       => __( 'Setup notice link label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'general',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Open Plan Your Day settings', 'plan-your-day' ),
+			],
+			'hero_eyebrow'           => [
+				'label'       => __( 'Top section eyebrow', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this short label above the main heading.', 'plan-your-day' ),
+				'group'       => 'general',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Trip builder', 'plan-your-day' ),
+			],
+			'hero_title'             => [
+				'label'       => __( 'Main planner heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'general',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Plan Your Day', 'plan-your-day' ),
+			],
+			'hero_intro'             => [
+				'label'       => __( 'Top section intro', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide the introductory helper sentence.', 'plan-your-day' ),
+				'group'       => 'general',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Search by category, choose real places from Google, then turn your picks into a walking trip.', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function starting_point_definitions(): array {
+		return [
+			'start_card_heading'                 => [
+				'label'       => __( 'Starting point heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Starting point', 'plan-your-day' ),
+			],
+			'start_card_help'                    => [
+				'label'       => __( 'Starting point helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper sentence.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Choose where the trip starts.', 'plan-your-day' ),
+			],
+			'start_mode_legend'                  => [
+				'label'       => __( 'Starting point options label', 'plan-your-day' ),
+				'description' => __( 'Used for screen readers.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Starting point mode', 'plan-your-day' ),
+			],
+			'start_mode_current_label'           => [
+				'label'       => __( 'Current location option label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Current location handoff', 'plan-your-day' ),
+			],
+			'start_mode_current_description'     => [
+				'label'       => __( 'Current location option helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper line.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Use the configured default location for on-page previews. Google Maps can start from the visitor\'s current location during handoff.', 'plan-your-day' ),
+			],
+			'start_mode_default_description'     => [
+				'label'       => __( 'Default location option helper text', 'plan-your-day' ),
+				'description' => __( 'Use {default_location} where the configured default location label should appear. Leave blank to hide this helper line.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Start from {default_location}.', 'plan-your-day' ),
+			],
+			'start_mode_custom_label'            => [
+				'label'       => __( 'Custom start option label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Custom starting point', 'plan-your-day' ),
+			],
+			'start_mode_custom_description'      => [
+				'label'       => __( 'Custom start option helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper line.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Enter a hotel name, landmark, or street address.', 'plan-your-day' ),
+			],
+			'custom_start_label'                 => [
+				'label'       => __( 'Custom start field label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Custom starting point', 'plan-your-day' ),
+			],
+			'custom_start_placeholder'           => [
+				'label'       => __( 'Custom start placeholder', 'plan-your-day' ),
+				'description' => __( 'Leave blank to remove the placeholder text.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Hotel name or street address', 'plan-your-day' ),
+			],
+			'update_results_button'              => [
+				'label'       => __( 'Update results button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Update results', 'plan-your-day' ),
+			],
+			'start_default_note'                 => [
+				'label'       => __( 'Default start helper note', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper note below the start options.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'The on-page results, preview, and Google Maps handoff use the configured default starting point.', 'plan-your-day' ),
+			],
+			'start_current_note'                 => [
+				'label'       => __( 'Current location helper note', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper note below the start options.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', 'plan-your-day' ),
+			],
+			'start_current_message'              => [
+				'label'       => __( 'Current location status message', 'plan-your-day' ),
+				'description' => __( 'Shown in the planner status message list when current location handoff is active.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', 'plan-your-day' ),
+			],
+			'start_custom_note'                  => [
+				'label'       => __( 'Custom start helper note', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper note below the start options.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'The on-page results, preview, and Google Maps handoff all use the custom starting point.', 'plan-your-day' ),
+			],
+			'start_custom_missing_note'          => [
+				'label'       => __( 'Missing custom start helper note', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper note when the custom start field is empty.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Add a custom address to replace the default fallback for search results, the route preview, and the Google Maps handoff.', 'plan-your-day' ),
+			],
+			'start_custom_missing_message'       => [
+				'label'       => __( 'Missing custom start warning', 'plan-your-day' ),
+				'description' => __( 'Shown in the planner status message list when custom start mode is selected without an address.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Add a custom address to replace the default fallback before finalizing the trip start.', 'plan-your-day' ),
+			],
+			'start_current_handoff_label'        => [
+				'label'       => __( 'Current location summary label', 'plan-your-day' ),
+				'description' => __( 'Shown in the trip summary when current location handoff is active.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Current location', 'plan-your-day' ),
+			],
+			'start_current_handoff_summary'      => [
+				'label'       => __( 'Current location summary phrase', 'plan-your-day' ),
+				'description' => __( 'Used inside route summary sentences.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'your current location', 'plan-your-day' ),
+			],
+			'start_default_fallback_label'       => [
+				'label'       => __( 'Default fallback summary label', 'plan-your-day' ),
+				'description' => __( 'Shown in the trip summary when custom start mode is selected without an address.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Default location fallback', 'plan-your-day' ),
+			],
+			'start_default_fallback_summary'     => [
+				'label'       => __( 'Default fallback summary phrase', 'plan-your-day' ),
+				'description' => __( 'Used inside route summary sentences when custom start mode is selected without an address.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'the default location until a custom starting point is provided', 'plan-your-day' ),
+			],
+			'start_default_location_fallback'    => [
+				'label'       => __( 'Default location fallback label', 'plan-your-day' ),
+				'description' => __( 'Used only if the configured default location label is missing.', 'plan-your-day' ),
+				'group'       => 'starting_point',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Default location', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function search_results_definitions(): array {
+		return [
+			'category_card_heading'                 => [
+				'label'       => __( 'Search section heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'What are you looking for?', 'plan-your-day' ),
+			],
+			'category_card_help'                    => [
+				'label'       => __( 'Search section helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper sentence.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Search for any category or use a category shortcut to load Google results.', 'plan-your-day' ),
+			],
+			'category_search_label'                 => [
+				'label'       => __( 'Category search field label', 'plan-your-day' ),
+				'description' => __( 'Used for screen readers.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Search categories', 'plan-your-day' ),
+			],
+			'category_search_placeholder'           => [
+				'label'       => __( 'Category search placeholder', 'plan-your-day' ),
+				'description' => __( 'Leave blank to remove the placeholder text.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Search categories', 'plan-your-day' ),
+			],
+			'category_search_button'                => [
+				'label'       => __( 'Category search button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Search', 'plan-your-day' ),
+			],
+			'custom_results_heading'                => [
+				'label'       => __( 'Custom search results heading', 'plan-your-day' ),
+				'description' => __( 'Use {search} where the current search term should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Results for {search}', 'plan-your-day' ),
+			],
+			'custom_results_description'            => [
+				'label'       => __( 'Custom search results helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper line.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Custom category search results.', 'plan-your-day' ),
+			],
+			'view_in_google_maps'                   => [
+				'label'       => __( 'Result map link label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'View in Google Maps', 'plan-your-day' ),
+			],
+			'view_place_in_google_maps_aria'        => [
+				'label'       => __( 'Result map link screen reader label', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'View {place} in Google Maps', 'plan-your-day' ),
+			],
+			'in_trip'                               => [
+				'label'       => __( 'Already added label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'In trip', 'plan-your-day' ),
+			],
+			'already_in_trip_aria'                  => [
+				'label'       => __( 'Already added screen reader label', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{place} is already in the trip', 'plan-your-day' ),
+			],
+			'add_to_trip'                           => [
+				'label'       => __( 'Add to trip button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Add to trip', 'plan-your-day' ),
+			],
+			'add_waypoint_aria'                     => [
+				'label'       => __( 'Add to trip screen reader label', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Add {place} to trip', 'plan-your-day' ),
+			],
+			'search_results_unavailable_heading'    => [
+				'label'       => __( 'Results unavailable heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Google results unavailable', 'plan-your-day' ),
+			],
+			'search_results_unavailable_body'       => [
+				'label'       => __( 'Results unavailable message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Google place results are unavailable right now. Try again later or open the Google Maps handoff link.', 'plan-your-day' ),
+			],
+			'search_results_prompt_heading'         => [
+				'label'       => __( 'No search yet heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Search for any category', 'plan-your-day' ),
+			],
+			'search_results_prompt_body_with_categories' => [
+				'label'       => __( 'No search yet message with category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text when category shortcuts are available.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Use the search box or choose a category to load real place results.', 'plan-your-day' ),
+			],
+			'search_results_prompt_body_no_categories' => [
+				'label'       => __( 'No search yet message without category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text when no category shortcuts are available.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Use the search box to load real place results.', 'plan-your-day' ),
+			],
+			'no_matching_results_heading'           => [
+				'label'       => __( 'No matching results heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'No matching Google results', 'plan-your-day' ),
+			],
+			'no_matching_results_body'              => [
+				'label'       => __( 'No matching results message', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Try a different search or change the starting area.', 'plan-your-day' ),
+			],
+			'maps_link_label_search'                => [
+				'label'       => __( 'Search-mode Google Maps link label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Explore in Google Maps', 'plan-your-day' ),
+			],
+			'preview_mode_label_search'             => [
+				'label'       => __( 'Search-mode preview label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Google place search', 'plan-your-day' ),
+			],
+			'overview_initial_with_categories'      => [
+				'label'       => __( 'Initial search overview with category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this overview sentence in the trip summary.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Search for any category or pick one below to load Google results, then add exact places to your trip.', 'plan-your-day' ),
+			],
+			'search_results_count_single'           => [
+				'label'       => __( 'Single result count label', 'plan-your-day' ),
+				'description' => __( 'Use {count} where the number of results should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{count} Google result', 'plan-your-day' ),
+			],
+			'search_results_count_plural'           => [
+				'label'       => __( 'Plural result count label', 'plan-your-day' ),
+				'description' => __( 'Use {count} where the number of results should appear.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{count} Google results', 'plan-your-day' ),
+			],
+			'no_results_loaded_label'               => [
+				'label'       => __( 'No results loaded label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'search_results',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'No Google results loaded', 'plan-your-day' ),
+			],
+			'overview_browse_search'                => [
+				'label'       => __( 'Search overview after results load', 'plan-your-day' ),
+				'description' => __( 'Use {search} for the active search and {start} for the current start summary. Leave blank to hide this overview sentence.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Browsing Google results for {search} near {start}. Add any result to start building a walking trip.', 'plan-your-day' ),
+			],
+			'search_preview_key_warning'            => [
+				'label'       => __( 'Search preview key warning', 'plan-your-day' ),
+				'description' => __( 'Shown when map preview is enabled without a valid Google Maps Embed API key.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Add a valid Google Maps Embed API key before relying on the on-site search preview.', 'plan-your-day' ),
+			],
+			'overview_initial_no_categories'        => [
+				'label'       => __( 'Initial search overview without category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this overview sentence when no category shortcuts are available.', 'plan-your-day' ),
+				'group'       => 'search_results',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Search for any category to load Google results, then add exact places to your trip.', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function trip_definitions(): array {
+		return [
+			'trip_empty_heading'                  => [
+				'label'       => __( 'Empty trip heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Start building the trip', 'plan-your-day' ),
+			],
+			'trip_empty_body'                     => [
+				'label'       => __( 'Empty trip message', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Search Google by category, then add the exact places you want as walking-trip waypoints.', 'plan-your-day' ),
+			],
+			'trip_card_heading'                   => [
+				'label'       => __( 'Trip section heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Trip waypoints', 'plan-your-day' ),
+			],
+			'trip_card_help'                      => [
+				'label'       => __( 'Trip section helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper sentence.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => false,
+				'default'     => __( 'Add exact places from Google, then use the move controls to set the walking trip order.', 'plan-your-day' ),
+			],
+			'clear_trip'                          => [
+				'label'       => __( 'Clear trip button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Clear trip', 'plan-your-day' ),
+			],
+			'move_up'                             => [
+				'label'       => __( 'Move up button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Move up', 'plan-your-day' ),
+			],
+			'move_down'                           => [
+				'label'       => __( 'Move down button', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Move down', 'plan-your-day' ),
+			],
+			'move_waypoint_up_aria'               => [
+				'label'       => __( 'Move up screen reader label', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Move {place} up in the trip', 'plan-your-day' ),
+			],
+			'move_waypoint_down_aria'             => [
+				'label'       => __( 'Move down screen reader label', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Move {place} down in the trip', 'plan-your-day' ),
+			],
+			'remove_waypoint_label'               => [
+				'label'       => __( 'Remove waypoint button', 'plan-your-day' ),
+				'description' => __( 'Use {place} where the place name should appear.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Remove {place}', 'plan-your-day' ),
+			],
+			'trip_not_started_label'              => [
+				'label'       => __( 'Trip not started label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Trip not started', 'plan-your-day' ),
+			],
+			'trip_timeout_warning'                => [
+				'label'       => __( 'Trip loading timeout warning', 'plan-your-day' ),
+				'description' => __( 'Shown when some selected places cannot be loaded before the request deadline.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The trip preview stopped loading more places before the request timed out. Try again or remove a few stops.', 'plan-your-day' ),
+			],
+			'trip_place_skipped_warning'          => [
+				'label'       => __( 'Skipped place warning', 'plan-your-day' ),
+				'description' => __( 'Shown when one selected place fails to load from Google.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'One selected place could not be loaded from Google and was skipped.', 'plan-your-day' ),
+			],
+			'trip_repeated_errors_warning'        => [
+				'label'       => __( 'Repeated place errors warning', 'plan-your-day' ),
+				'description' => __( 'Shown when repeated Google place errors stop trip preview loading early.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The trip preview stopped loading more places after repeated Google place errors. Try again later or remove any invalid stops.', 'plan-your-day' ),
+			],
+			'unresolved_waypoint_label'           => [
+				'label'       => __( 'Unresolved waypoint label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Selected place needs attention', 'plan-your-day' ),
+			],
+			'unresolved_waypoint_address'         => [
+				'label'       => __( 'Unresolved waypoint message', 'plan-your-day' ),
+				'description' => __( 'Shown in place of the address when Google cannot load a selected place.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Google could not load this place right now. It is still selected and can be retried, moved, or removed.', 'plan-your-day' ),
+			],
+			'trip_count_single'                   => [
+				'label'       => __( 'Single waypoint count label', 'plan-your-day' ),
+				'description' => __( 'Use {count} where the number of selected waypoints should appear.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{count} waypoint selected', 'plan-your-day' ),
+			],
+			'trip_count_plural'                   => [
+				'label'       => __( 'Plural waypoint count label', 'plan-your-day' ),
+				'description' => __( 'Use {count} where the number of selected waypoints should appear.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{count} waypoints selected', 'plan-your-day' ),
+			],
+			'trip_route_unresolved'               => [
+				'label'       => __( 'Unresolved trip route summary', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'One or more selected places still need to load before the walking trip can be previewed.', 'plan-your-day' ),
+			],
+			'trip_overview_template'              => [
+				'label'       => __( 'Trip summary overview template', 'plan-your-day' ),
+				'description' => __( 'Use {trip_count} for the waypoint count label and {route_description} for the route sentence. Leave blank to hide this overview sentence.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( '{trip_count}. {route_description}', 'plan-your-day' ),
+			],
+			'trip_unavailable_until_loaded_warning' => [
+				'label'       => __( 'Trip preview unavailable warning', 'plan-your-day' ),
+				'description' => __( 'Shown when one or more selected places are still unresolved.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The trip preview and Google Maps handoff will stay unavailable until every selected place loads successfully.', 'plan-your-day' ),
+			],
+			'trip_preview_key_warning'            => [
+				'label'       => __( 'Trip preview key warning', 'plan-your-day' ),
+				'description' => __( 'Shown when trip preview is enabled without a valid Google Maps Embed API key.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Add a valid Google Maps Embed API key before relying on the on-site trip preview.', 'plan-your-day' ),
+			],
+			'maps_link_label_trip'                => [
+				'label'       => __( 'Trip-mode Google Maps link label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Open trip in Google Maps', 'plan-your-day' ),
+			],
+			'preview_mode_label_trip'             => [
+				'label'       => __( 'Trip-mode preview label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Walking directions', 'plan-your-day' ),
+			],
+			'route_description_direct'            => [
+				'label'       => __( 'Direct route summary template', 'plan-your-day' ),
+				'description' => __( 'Use {start} for the trip start and {destination} for the final stop.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Walking directions run from {start} to {destination}.', 'plan-your-day' ),
+			],
+			'route_description_via'               => [
+				'label'       => __( 'Route summary with stops template', 'plan-your-day' ),
+				'description' => __( 'Use {start} for the trip start, {destination} for the final stop, and {via} for the intermediate stops.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Walking directions run from {start} to {destination} via {via}.', 'plan-your-day' ),
+			],
+			'label_list_pair'                     => [
+				'label'       => __( 'Two-stop list template', 'plan-your-day' ),
+				'description' => __( 'Use {first} and {second}.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{first} and {second}', 'plan-your-day' ),
+			],
+			'label_list_many'                     => [
+				'label'       => __( 'Multi-stop list template', 'plan-your-day' ),
+				'description' => __( 'Use {list} for the earlier stops and {last} for the final stop in the list.', 'plan-your-day' ),
+				'group'       => 'trip',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{list}, and {last}', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function preview_definitions(): array {
+		return [
+			'not_selected'                         => [
+				'label'       => __( 'Not selected label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Not selected', 'plan-your-day' ),
+			],
+			'preview_card_heading'                 => [
+				'label'       => __( 'Preview section heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Trip preview', 'plan-your-day' ),
+			],
+			'preview_card_help'                    => [
+				'label'       => __( 'Preview section helper text', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper sentence.', 'plan-your-day' ),
+				'group'       => 'preview',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'The map starts as a Google place search and switches to walking directions once you add exact waypoints.', 'plan-your-day' ),
+			],
+			'preview_iframe_title'                 => [
+				'label'       => __( 'Map iframe title', 'plan-your-day' ),
+				'description' => __( 'Used as the accessible title for the embedded Google Map.', 'plan-your-day' ),
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Google Maps trip preview', 'plan-your-day' ),
+			],
+			'summary_eyebrow'                      => [
+				'label'       => __( 'Trip summary eyebrow', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this short label above the trip summary.', 'plan-your-day' ),
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => false,
+				'default'     => __( 'Trip summary', 'plan-your-day' ),
+			],
+			'summary_active_search_label'          => [
+				'label'       => __( 'Summary active search label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Active search', 'plan-your-day' ),
+			],
+			'summary_results_label'                => [
+				'label'       => __( 'Summary results label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Google results', 'plan-your-day' ),
+			],
+			'summary_start_label'                  => [
+				'label'       => __( 'Summary start label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Google Maps start', 'plan-your-day' ),
+			],
+			'summary_map_mode_label'               => [
+				'label'       => __( 'Summary map mode label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Map mode', 'plan-your-day' ),
+			],
+			'summary_open_maps_label'              => [
+				'label'       => __( 'Summary Google Maps label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Open in Google Maps', 'plan-your-day' ),
+			],
+			'preview_prompt_heading'               => [
+				'label'       => __( 'No preview yet heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Start with a category search', 'plan-your-day' ),
+			],
+			'preview_prompt_body_with_categories'  => [
+				'label'       => __( 'No preview yet message with category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text when category shortcuts are available.', 'plan-your-day' ),
+				'group'       => 'preview',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Use the search box or choose a category to load Google results, then add the places you want to turn into trip waypoints.', 'plan-your-day' ),
+			],
+			'preview_prompt_body_no_categories'    => [
+				'label'       => __( 'No preview yet message without category shortcuts', 'plan-your-day' ),
+				'description' => __( 'Leave blank to hide this helper text when no category shortcuts are available.', 'plan-your-day' ),
+				'group'       => 'preview',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => false,
+				'default'     => __( 'Use the search box to load Google results, then add the places you want to turn into trip waypoints.', 'plan-your-day' ),
+			],
+			'search_preview_unavailable_heading'   => [
+				'label'       => __( 'Search preview unavailable heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Search preview unavailable', 'plan-your-day' ),
+			],
+			'search_preview_unavailable_body'      => [
+				'label'       => __( 'Search preview unavailable message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The on-page map preview needs a valid Google Maps Embed API key. The Google Maps search link still works.', 'plan-your-day' ),
+			],
+			'trip_preview_unavailable_heading'     => [
+				'label'       => __( 'Trip preview unavailable heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Trip preview unavailable', 'plan-your-day' ),
+			],
+			'trip_preview_unavailable_body'        => [
+				'label'       => __( 'Trip preview unavailable message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'preview',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The on-page trip preview needs a valid Google Maps Embed API key. The Google Maps handoff link still works.', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function status_definitions(): array {
+		return [
+			'hydration_loading_message'              => [
+				'label'       => __( 'Verified loading message', 'plan-your-day' ),
+				'description' => __( 'Shown while the planner reloads saved state through the verified request path.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => true,
+				'default'     => __( 'Loading planner state through a verified request.', 'plan-your-day' ),
+			],
+			'loading_results_label'                 => [
+				'label'       => __( 'Loading results count label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading Google results...', 'plan-your-day' ),
+			],
+			'loading_results_heading'               => [
+				'label'       => __( 'Loading results heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading Google results', 'plan-your-day' ),
+			],
+			'loading_results_body'                  => [
+				'label'       => __( 'Loading results message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+			],
+			'loading_trip_count'                    => [
+				'label'       => __( 'Loading trip count label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading trip waypoints...', 'plan-your-day' ),
+			],
+			'loading_trip_heading'                  => [
+				'label'       => __( 'Loading trip heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading trip waypoints', 'plan-your-day' ),
+			],
+			'loading_trip_body'                     => [
+				'label'       => __( 'Loading trip message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+			],
+			'loading_trip_preview_mode'             => [
+				'label'       => __( 'Loading trip preview label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading trip preview', 'plan-your-day' ),
+			],
+			'loading_trip_preview_heading'          => [
+				'label'       => __( 'Loading trip preview heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading trip preview', 'plan-your-day' ),
+			],
+			'loading_trip_preview_body'             => [
+				'label'       => __( 'Loading trip preview message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner is loading your saved trip through the secure request path.', 'plan-your-day' ),
+			],
+			'loading_search_preview_mode'           => [
+				'label'       => __( 'Loading search preview label', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading search preview', 'plan-your-day' ),
+			],
+			'loading_search_preview_heading'        => [
+				'label'       => __( 'Loading search preview heading', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Loading search preview', 'plan-your-day' ),
+			],
+			'loading_search_preview_body'           => [
+				'label'       => __( 'Loading search preview message', 'plan-your-day' ),
+				'description' => '',
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner is loading your saved search through the secure request path.', 'plan-your-day' ),
+			],
+			'request_failed'                        => [
+				'label'       => __( 'Generic request failure message', 'plan-your-day' ),
+				'description' => __( 'Shown when a frontend request fails without a more specific message.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner request could not be completed. Refresh the page and try again.', 'plan-your-day' ),
+			],
+			'request_verification_failed'           => [
+				'label'       => __( 'Request verification failure message', 'plan-your-day' ),
+				'description' => __( 'Shown when a planner request cannot be verified.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'The planner request could not be verified. Refresh the page and try again.', 'plan-your-day' ),
+			],
+			'rate_limited'                          => [
+				'label'       => __( 'Rate limit message', 'plan-your-day' ),
+				'description' => __( 'Shown when the public planner rate limit is reached.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 3,
+				'required'    => true,
+				'default'     => __( 'Planner requests are temporarily limited. Please wait a minute and try again.', 'plan-your-day' ),
+			],
+			'results_updated_announcement'          => [
+				'label'       => __( 'Results updated announcement', 'plan-your-day' ),
+				'description' => __( 'Announced to screen readers after search results change.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Results updated.', 'plan-your-day' ),
+			],
+			'category_results_expanded_announcement' => [
+				'label'       => __( 'Category expanded announcement', 'plan-your-day' ),
+				'description' => __( 'Use {category} where the category label should appear.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{category} results expanded.', 'plan-your-day' ),
+			],
+			'category_results_collapsed_announcement' => [
+				'label'       => __( 'Category collapsed announcement', 'plan-your-day' ),
+				'description' => __( 'Use {category} where the category label should appear.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( '{category} results collapsed.', 'plan-your-day' ),
+			],
+			'custom_results_expanded_announcement' => [
+				'label'       => __( 'Custom results expanded announcement', 'plan-your-day' ),
+				'description' => __( 'Announced to screen readers when the custom results panel expands.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Custom search results expanded.', 'plan-your-day' ),
+			],
+			'custom_results_collapsed_announcement' => [
+				'label'       => __( 'Custom results collapsed announcement', 'plan-your-day' ),
+				'description' => __( 'Announced to screen readers when the custom results panel collapses.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Custom search results collapsed.', 'plan-your-day' ),
+			],
+			'trip_updated_announcement'            => [
+				'label'       => __( 'Trip updated announcement', 'plan-your-day' ),
+				'description' => __( 'Announced to screen readers after trip waypoints change.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Trip updated.', 'plan-your-day' ),
+			],
+			'starting_point_updated_announcement'  => [
+				'label'       => __( 'Starting point updated announcement', 'plan-your-day' ),
+				'description' => __( 'Announced to screen readers after the starting point changes.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Starting point updated.', 'plan-your-day' ),
+			],
+			'open_maps_disabled_announcement'      => [
+				'label'       => __( 'Open in Google Maps unavailable announcement', 'plan-your-day' ),
+				'description' => __( 'Announced if the Google Maps handoff link is disabled.', 'plan-your-day' ),
+				'group'       => 'status_messages',
+				'type'        => 'textarea',
+				'rows'        => 2,
+				'required'    => true,
+				'default'     => __( 'Add at least one waypoint before opening the trip in Google Maps.', 'plan-your-day' ),
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, array{label: string, description: string, group: string, type: string, required: bool, default: string, rows?: int}>
+	 */
+	private static function distance_definitions(): array {
+		return [
+			'distance_under_threshold_without_reference' => [
+				'label'       => __( 'Very short distance without start label', 'plan-your-day' ),
+				'description' => __( 'Use {unit} where the distance unit abbreviation should appear.', 'plan-your-day' ),
+				'group'       => 'distance',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Less than 0.1 {unit} away', 'plan-your-day' ),
+			],
+			'distance_under_threshold_with_reference' => [
+				'label'       => __( 'Very short distance with start label', 'plan-your-day' ),
+				'description' => __( 'Use {unit} for the distance unit abbreviation and {start} for the start label.', 'plan-your-day' ),
+				'group'       => 'distance',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Less than 0.1 {unit} from {start}', 'plan-your-day' ),
+			],
+			'distance_approx_without_reference'    => [
+				'label'       => __( 'Approximate distance without start label', 'plan-your-day' ),
+				'description' => __( 'Use {distance} for the number and {unit} for the distance unit abbreviation.', 'plan-your-day' ),
+				'group'       => 'distance',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Approx. {distance} {unit} away', 'plan-your-day' ),
+			],
+			'distance_approx_with_reference'       => [
+				'label'       => __( 'Approximate distance with start label', 'plan-your-day' ),
+				'description' => __( 'Use {distance} for the number, {unit} for the distance unit abbreviation, and {start} for the start label.', 'plan-your-day' ),
+				'group'       => 'distance',
+				'type'        => 'text',
+				'required'    => true,
+				'default'     => __( 'Approx. {distance} {unit} from {start}', 'plan-your-day' ),
+			],
+		];
+	}
+}

--- a/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
+++ b/plugin/plan-your-day/src/Frontend/PlannerRenderer.php
@@ -53,7 +53,7 @@ final class PlannerRenderer {
 		);
 
 		if ( $should_hydrate_on_load ) {
-			$planner_state = InitialPlannerHydration::apply_loading_placeholders( $planner_state );
+			$planner_state = InitialPlannerHydration::apply_loading_placeholders( $planner_state, $this->settings->get_frontend_copy() );
 		}
 
 		$category_catalog    = $this->category_catalog->get_all();
@@ -79,11 +79,13 @@ final class PlannerRenderer {
 			<div class="plan-your-day__surface">
 				<header class="plan-your-day__hero">
 					<div class="plan-your-day__hero-copy">
-						<p class="plan-your-day__eyebrow"><?php esc_html_e( 'Trip builder', 'plan-your-day' ); ?></p>
-						<h2 id="<?php echo esc_attr( $title_id ); ?>"><?php esc_html_e( 'Plan Your Day', 'plan-your-day' ); ?></h2>
-						<p class="plan-your-day__intro">
-							<?php esc_html_e( 'Search by category, choose real places from Google, then turn your picks into a walking trip.', 'plan-your-day' ); ?>
-						</p>
+						<?php if ( '' !== $this->settings->get_frontend_copy_value( 'hero_eyebrow' ) ) : ?>
+							<p class="plan-your-day__eyebrow"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'hero_eyebrow' ) ); ?></p>
+						<?php endif; ?>
+						<h2 id="<?php echo esc_attr( $title_id ); ?>"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'hero_title' ) ); ?></h2>
+						<?php if ( '' !== $this->settings->get_frontend_copy_value( 'hero_intro' ) ) : ?>
+							<p class="plan-your-day__intro"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'hero_intro' ) ); ?></p>
+						<?php endif; ?>
 					</div>
 				</header>
 
@@ -125,22 +127,14 @@ final class PlannerRenderer {
 			id="<?php echo esc_attr( $instance_id ); ?>"
 			aria-labelledby="<?php echo esc_attr( $title_id ); ?>">
 			<div class="plan-your-day__surface">
-				<h2 id="<?php echo esc_attr( $title_id ); ?>"><?php esc_html_e( 'Plan Your Day setup needed', 'plan-your-day' ); ?></h2>
+				<h2 id="<?php echo esc_attr( $title_id ); ?>"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'setup_notice_title' ) ); ?></h2>
 				<p>
-					<?php
-					echo esc_html(
-						sprintf(
-							/* translators: %s is a comma-separated list of missing setting labels. */
-							__( 'The planner needs required settings before it can render: %s.', 'plan-your-day' ),
-							$missing
-						)
-					);
-					?>
+					<?php echo esc_html( $this->settings->format_frontend_copy( 'setup_notice_body', [ 'settings' => $missing ] ) ); ?>
 				</p>
 				<?php if ( current_user_can( 'manage_options' ) ) : ?>
 					<p>
 						<a href="<?php echo esc_url( admin_url( 'options-general.php?page=' . Settings::PAGE_SLUG ) ); ?>">
-							<?php esc_html_e( 'Open Plan Your Day settings', 'plan-your-day' ); ?>
+							<?php echo esc_html( $this->settings->get_frontend_copy_value( 'setup_notice_link' ) ); ?>
 						</a>
 					</p>
 				<?php endif; ?>
@@ -157,18 +151,21 @@ final class PlannerRenderer {
 		$custom_start_id    = $instance_id . '-custom-start';
 		$start_heading_id   = $instance_id . '-start-heading';
 		$selected_waypoints = (array) $planner_state['selected_waypoint_ids'];
+		$start_help_text    = $this->settings->get_frontend_copy_value( 'start_card_help' );
 		?>
 		<section class="plan-your-day__card" aria-labelledby="<?php echo esc_attr( $start_heading_id ); ?>">
 			<div class="plan-your-day__card-header">
 				<div>
-					<h3 id="<?php echo esc_attr( $start_heading_id ); ?>"><?php esc_html_e( 'Starting point', 'plan-your-day' ); ?></h3>
-					<p id="<?php echo esc_attr( $start_help_id ); ?>"><?php esc_html_e( 'Choose where the trip starts.', 'plan-your-day' ); ?></p>
+					<h3 id="<?php echo esc_attr( $start_heading_id ); ?>"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'start_card_heading' ) ); ?></h3>
+					<?php if ( '' !== $start_help_text ) : ?>
+						<p id="<?php echo esc_attr( $start_help_id ); ?>"><?php echo esc_html( $start_help_text ); ?></p>
+					<?php endif; ?>
 				</div>
 			</div>
 
 			<div class="plan-your-day__start-panel" id="<?php echo esc_attr( $start_panel_id ); ?>" data-plan-start-panel>
-				<fieldset class="plan-your-day__fieldset" aria-describedby="<?php echo esc_attr( $start_help_id ); ?>">
-					<legend class="screen-reader-text"><?php esc_html_e( 'Starting point mode', 'plan-your-day' ); ?></legend>
+				<fieldset class="plan-your-day__fieldset" <?php echo '' !== $start_help_text ? 'aria-describedby="' . esc_attr( $start_help_id ) . '"' : ''; ?>>
+					<legend class="screen-reader-text"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'start_mode_legend' ) ); ?></legend>
 					<div class="plan-your-day__start-options">
 						<?php foreach ( $start_points as $start_key => $start_point ) : ?>
 							<label class="plan-your-day__start-option">
@@ -189,13 +186,13 @@ final class PlannerRenderer {
 						class="plan-your-day__custom-start"
 						data-plan-custom-start-wrap
 						<?php echo Settings::START_MODE_CUSTOM === $planner_state['start_mode'] ? '' : 'hidden'; ?>>
-						<label for="<?php echo esc_attr( $custom_start_id ); ?>"><?php esc_html_e( 'Custom starting point', 'plan-your-day' ); ?></label>
+						<label for="<?php echo esc_attr( $custom_start_id ); ?>"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'custom_start_label' ) ); ?></label>
 						<input
 							id="<?php echo esc_attr( $custom_start_id ); ?>"
 							type="text"
 							name="custom_start"
 							value="<?php echo esc_attr( $planner_state['custom_start'] ); ?>"
-							placeholder="<?php esc_attr_e( 'Hotel name or street address', 'plan-your-day' ); ?>"
+							placeholder="<?php echo esc_attr( $this->settings->get_frontend_copy_value( 'custom_start_placeholder' ) ); ?>"
 							autocomplete="street-address"
 							data-plan-custom-start>
 					</div>
@@ -212,7 +209,7 @@ final class PlannerRenderer {
 				</div>
 
 				<div class="plan-your-day__actions">
-					<button class="plan-your-day__submit" type="submit"><?php esc_html_e( 'Update results', 'plan-your-day' ); ?></button>
+					<button class="plan-your-day__submit" type="submit"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'update_results_button' ) ); ?></button>
 				</div>
 			</div>
 		</section>
@@ -227,32 +224,33 @@ final class PlannerRenderer {
 		$custom_results_trigger_id = $instance_id . '-custom-results-trigger';
 		$custom_results_panel_id   = $instance_id . '-custom-results-panel';
 		$has_custom_search         = (bool) $planner_state['is_custom_search'];
+		$category_help_text        = $this->settings->get_frontend_copy_value( 'category_card_help' );
 		?>
 		<section class="plan-your-day__card" aria-labelledby="<?php echo esc_attr( $heading_id ); ?>">
 			<div class="plan-your-day__card-header">
 				<div>
-					<h3 id="<?php echo esc_attr( $heading_id ); ?>" data-plan-results-heading><?php esc_html_e( 'What are you looking for?', 'plan-your-day' ); ?></h3>
-					<p id="<?php echo esc_attr( $category_help_id ); ?>">
-						<?php esc_html_e( 'Search for any category or use a preset shortcut to load Google results.', 'plan-your-day' ); ?>
-					</p>
+					<h3 id="<?php echo esc_attr( $heading_id ); ?>" data-plan-results-heading><?php echo esc_html( $this->settings->get_frontend_copy_value( 'category_card_heading' ) ); ?></h3>
+					<?php if ( '' !== $category_help_text ) : ?>
+						<p id="<?php echo esc_attr( $category_help_id ); ?>"><?php echo esc_html( $category_help_text ); ?></p>
+					<?php endif; ?>
 				</div>
 				<span class="plan-your-day__count-pill" data-plan-results-count><?php echo esc_html( $planner_state['search_results_label'] ); ?></span>
 			</div>
 
 			<div class="plan-your-day__category-search">
-				<label for="<?php echo esc_attr( $category_search_id ); ?>" class="screen-reader-text"><?php esc_html_e( 'Search categories', 'plan-your-day' ); ?></label>
+				<label for="<?php echo esc_attr( $category_search_id ); ?>" class="screen-reader-text"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'category_search_label' ) ); ?></label>
 				<div class="plan-your-day__category-search-controls">
 					<input
 						id="<?php echo esc_attr( $category_search_id ); ?>"
 						type="search"
 						name="category_search"
 						value="<?php echo esc_attr( (string) $planner_state['category_search'] ); ?>"
-						placeholder="<?php esc_attr_e( 'Search categories', 'plan-your-day' ); ?>"
+						placeholder="<?php echo esc_attr( $this->settings->get_frontend_copy_value( 'category_search_placeholder' ) ); ?>"
 						autocomplete="off"
 						spellcheck="false"
 						data-plan-category-search>
 					<button class="plan-your-day__category-search-button" type="submit" data-plan-action="search-category-query">
-						<?php esc_html_e( 'Search', 'plan-your-day' ); ?>
+						<?php echo esc_html( $this->settings->get_frontend_copy_value( 'category_search_button' ) ); ?>
 					</button>
 				</div>
 			</div>
@@ -275,17 +273,18 @@ final class PlannerRenderer {
 									<?php
 									echo esc_html(
 										$has_custom_search
-											? sprintf(
-												/* translators: %s is the active search label. */
-												__( 'Results for %s', 'plan-your-day' ),
-												$planner_state['active_search_label']
+											? $this->settings->format_frontend_copy(
+												'custom_results_heading',
+												[
+													'search' => (string) $planner_state['active_search_label'],
+												]
 											)
 											: $results_empty_state['heading']
 									);
 									?>
 								</span>
 								<span class="plan-your-day__category-description" data-plan-custom-results-description>
-									<?php esc_html_e( 'Custom category search results.', 'plan-your-day' ); ?>
+									<?php echo esc_html( $this->settings->get_frontend_copy_value( 'custom_results_description' ) ); ?>
 								</span>
 							</span>
 							<span class="plan-your-day__category-trigger-side" aria-hidden="true">
@@ -319,7 +318,7 @@ final class PlannerRenderer {
 			</div>
 
 			<?php if ( [] !== $category_catalog ) : ?>
-				<div class="plan-your-day__category-accordion" aria-describedby="<?php echo esc_attr( $category_help_id ); ?>">
+				<div class="plan-your-day__category-accordion" <?php echo '' !== $category_help_text ? 'aria-describedby="' . esc_attr( $category_help_id ) . '"' : ''; ?>>
 					<?php foreach ( $category_catalog as $category_key => $category ) : ?>
 						<?php
 						$is_active          = $planner_state['category_key'] === $category_key;
@@ -402,22 +401,20 @@ final class PlannerRenderer {
 							rel="noopener noreferrer"
 							aria-label="
 							<?php
-							/* translators: %s is a place label. */
-							echo esc_attr( sprintf( __( 'View %s in Google Maps', 'plan-your-day' ), $label ) );
+							echo esc_attr( $this->settings->format_frontend_copy( 'view_place_in_google_maps_aria', [ 'place' => $label ] ) );
 							?>
 							">
-						<?php esc_html_e( 'View in Google Maps', 'plan-your-day' ); ?>
+						<?php echo esc_html( $this->settings->get_frontend_copy_value( 'view_in_google_maps' ) ); ?>
 					</a>
 				<?php endif; ?>
 
 				<?php if ( $is_in_trip ) : ?>
 						<span class="plan-your-day__result-added" aria-label="
 						<?php
-						/* translators: %s is a place label. */
-						echo esc_attr( sprintf( __( '%s is already in the trip', 'plan-your-day' ), $label ) );
+						echo esc_attr( $this->settings->format_frontend_copy( 'already_in_trip_aria', [ 'place' => $label ] ) );
 						?>
 						">
-						<?php esc_html_e( 'In trip', 'plan-your-day' ); ?>
+						<?php echo esc_html( $this->settings->get_frontend_copy_value( 'in_trip' ) ); ?>
 					</span>
 				<?php else : ?>
 					<button
@@ -430,11 +427,10 @@ final class PlannerRenderer {
 							data-place-id="<?php echo esc_attr( $place_id ); ?>"
 							aria-label="
 							<?php
-							/* translators: %s is a place label. */
-							echo esc_attr( sprintf( __( 'Add %s to trip', 'plan-your-day' ), $label ) );
+							echo esc_attr( $this->settings->format_frontend_copy( 'add_waypoint_aria', [ 'place' => $label ] ) );
 							?>
 							">
-						<?php esc_html_e( 'Add to trip', 'plan-your-day' ); ?>
+						<?php echo esc_html( $this->settings->get_frontend_copy_value( 'add_to_trip' ) ); ?>
 					</button>
 				<?php endif; ?>
 			</div>
@@ -446,32 +442,35 @@ final class PlannerRenderer {
 		$heading_id       = $instance_id . '-trip-heading';
 		$help_id          = $instance_id . '-trip-help';
 		$waypoints        = (array) $planner_state['trip_waypoints'];
+		$trip_help_text   = $this->settings->get_frontend_copy_value( 'trip_card_help' );
 		$trip_empty_state = isset( $planner_state['trip_empty_state'] )
 			? (array) $planner_state['trip_empty_state']
 			: [
-				'heading' => __( 'Start building the trip', 'plan-your-day' ),
-				'body'    => __( 'Search Google by category, then add the exact places you want as walking-trip waypoints.', 'plan-your-day' ),
+				'heading' => $this->settings->get_frontend_copy_value( 'trip_empty_heading' ),
+				'body'    => $this->settings->get_frontend_copy_value( 'trip_empty_body' ),
 			];
 		?>
 		<section class="plan-your-day__card" aria-labelledby="<?php echo esc_attr( $heading_id ); ?>">
 			<div class="plan-your-day__card-header">
 				<div>
-					<h3 id="<?php echo esc_attr( $heading_id ); ?>" tabindex="-1" data-plan-trip-heading><?php esc_html_e( 'Trip waypoints', 'plan-your-day' ); ?></h3>
-					<p id="<?php echo esc_attr( $help_id ); ?>"><?php esc_html_e( 'Add exact places from Google, then use the move controls to set the walking trip order.', 'plan-your-day' ); ?></p>
+					<h3 id="<?php echo esc_attr( $heading_id ); ?>" tabindex="-1" data-plan-trip-heading><?php echo esc_html( $this->settings->get_frontend_copy_value( 'trip_card_heading' ) ); ?></h3>
+					<?php if ( '' !== $trip_help_text ) : ?>
+						<p id="<?php echo esc_attr( $help_id ); ?>"><?php echo esc_html( $trip_help_text ); ?></p>
+					<?php endif; ?>
 				</div>
 				<div class="plan-your-day__trip-header-actions" data-plan-trip-header-actions>
 					<span class="plan-your-day__count-pill" data-plan-trip-count><?php echo esc_html( $planner_state['trip_count_label'] ); ?></span>
 					<?php if ( [] !== (array) $planner_state['selected_waypoint_ids'] ) : ?>
 						<button class="plan-your-day__clear-link" type="submit" name="clear_trip" value="1" data-plan-clear-trip data-plan-action="clear-trip" data-plan-route-mutation>
-							<?php esc_html_e( 'Clear trip', 'plan-your-day' ); ?>
+							<?php echo esc_html( $this->settings->get_frontend_copy_value( 'clear_trip' ) ); ?>
 						</button>
 					<?php endif; ?>
 				</div>
 			</div>
 
-			<div data-plan-trip-region data-plan-trip-help-id="<?php echo esc_attr( $help_id ); ?>">
+			<div data-plan-trip-region data-plan-trip-help-id="<?php echo esc_attr( '' !== $trip_help_text ? $help_id : '' ); ?>">
 				<?php if ( [] !== $waypoints ) : ?>
-					<ol class="plan-your-day__trip-list" aria-describedby="<?php echo esc_attr( $help_id ); ?>" data-plan-trip-list>
+					<ol class="plan-your-day__trip-list" <?php echo '' !== $trip_help_text ? 'aria-describedby="' . esc_attr( $help_id ) . '"' : ''; ?> data-plan-trip-list>
 						<?php foreach ( $waypoints as $index => $waypoint ) : ?>
 							<?php $this->render_trip_waypoint( $waypoint, $index, count( $waypoints ) ); ?>
 						<?php endforeach; ?>
@@ -508,12 +507,11 @@ final class PlannerRenderer {
 						data-plan-route-mutation
 						aria-label="
 						<?php
-						/* translators: %s is a place label. */
-						echo esc_attr( sprintf( __( 'Move %s up in the trip', 'plan-your-day' ), $label ) );
+						echo esc_attr( $this->settings->format_frontend_copy( 'move_waypoint_up_aria', [ 'place' => $label ] ) );
 						?>
 						"
 					<?php disabled( 0 === $index ); ?>>
-					<?php esc_html_e( 'Move up', 'plan-your-day' ); ?>
+					<?php echo esc_html( $this->settings->get_frontend_copy_value( 'move_up' ) ); ?>
 				</button>
 				<button
 					class="plan-your-day__reorder-button plan-your-day__reorder-button--down"
@@ -523,18 +521,14 @@ final class PlannerRenderer {
 						data-plan-route-mutation
 						aria-label="
 						<?php
-						/* translators: %s is a place label. */
-						echo esc_attr( sprintf( __( 'Move %s down in the trip', 'plan-your-day' ), $label ) );
+						echo esc_attr( $this->settings->format_frontend_copy( 'move_waypoint_down_aria', [ 'place' => $label ] ) );
 						?>
 						"
 					<?php disabled( $index >= $waypoint_count - 1 ); ?>>
-					<?php esc_html_e( 'Move down', 'plan-your-day' ); ?>
+					<?php echo esc_html( $this->settings->get_frontend_copy_value( 'move_down' ) ); ?>
 					</button>
 					<button type="submit" name="remove_waypoint" value="<?php echo esc_attr( $place_id ); ?>" data-plan-action="remove-waypoint" data-plan-route-mutation data-place-id="<?php echo esc_attr( $place_id ); ?>">
-						<?php
-						/* translators: %s is a place label. */
-						echo esc_html( sprintf( __( 'Remove %s', 'plan-your-day' ), $label ) );
-						?>
+						<?php echo esc_html( $this->settings->format_frontend_copy( 'remove_waypoint_label', [ 'place' => $label ] ) ); ?>
 					</button>
 			</div>
 		</li>
@@ -544,13 +538,15 @@ final class PlannerRenderer {
 	private function render_preview_card( string $instance_id, array $planner_state, array $preview_empty_state, bool $maps_link_enabled ): void {
 		$heading_id     = $instance_id . '-preview-heading';
 		$maps_label_id  = $instance_id . '-maps-label';
-		$category_label = $planner_state['has_search'] ? (string) $planner_state['active_search_label'] : __( 'Not selected', 'plan-your-day' );
+		$category_label = $planner_state['has_search'] ? (string) $planner_state['active_search_label'] : $this->settings->get_frontend_copy_value( 'not_selected' );
 		?>
 		<section class="plan-your-day__card plan-your-day__preview-card" aria-labelledby="<?php echo esc_attr( $heading_id ); ?>" data-plan-preview-card>
 			<div class="plan-your-day__card-header">
 				<div>
-					<h3 id="<?php echo esc_attr( $heading_id ); ?>" tabindex="-1" data-plan-preview-heading><?php esc_html_e( 'Trip preview', 'plan-your-day' ); ?></h3>
-					<p><?php esc_html_e( 'The map starts as a Google place search and switches to walking directions once you add exact waypoints.', 'plan-your-day' ); ?></p>
+					<h3 id="<?php echo esc_attr( $heading_id ); ?>" tabindex="-1" data-plan-preview-heading><?php echo esc_html( $this->settings->get_frontend_copy_value( 'preview_card_heading' ) ); ?></h3>
+					<?php if ( '' !== $this->settings->get_frontend_copy_value( 'preview_card_help' ) ) : ?>
+						<p><?php echo esc_html( $this->settings->get_frontend_copy_value( 'preview_card_help' ) ); ?></p>
+					<?php endif; ?>
 				</div>
 			</div>
 
@@ -560,7 +556,7 @@ final class PlannerRenderer {
 			<div class="plan-your-day__map-wrap" data-plan-map-wrap <?php echo '' !== $planner_state['iframe_src'] ? '' : 'hidden'; ?>>
 				<iframe
 					class="plan-your-day__map-frame"
-					title="<?php esc_attr_e( 'Google Maps trip preview', 'plan-your-day' ); ?>"
+					title="<?php echo esc_attr( $this->settings->get_frontend_copy_value( 'preview_iframe_title' ) ); ?>"
 					src="<?php echo '' !== $planner_state['iframe_src'] ? esc_url( $planner_state['iframe_src'] ) : ''; ?>"
 					loading="lazy"
 					referrerpolicy="no-referrer-when-downgrade"
@@ -575,31 +571,33 @@ final class PlannerRenderer {
 
 			<div class="plan-your-day__summary" data-plan-summary>
 				<div class="plan-your-day__summary-top">
-					<p class="plan-your-day__summary-eyebrow"><?php esc_html_e( 'Trip summary', 'plan-your-day' ); ?></p>
+					<?php if ( '' !== $this->settings->get_frontend_copy_value( 'summary_eyebrow' ) ) : ?>
+						<p class="plan-your-day__summary-eyebrow"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_eyebrow' ) ); ?></p>
+					<?php endif; ?>
 					<p class="plan-your-day__summary-count" data-plan-summary-count><?php echo esc_html( $planner_state['trip_count_label'] ); ?></p>
 				</div>
 				<p class="plan-your-day__summary-overview" data-plan-summary-overview><?php echo esc_html( $planner_state['overview'] ); ?></p>
 				<dl class="plan-your-day__summary-grid">
 					<div>
-						<dt><?php esc_html_e( 'Active search', 'plan-your-day' ); ?></dt>
+						<dt><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_active_search_label' ) ); ?></dt>
 						<dd data-plan-summary-category><?php echo esc_html( $category_label ); ?></dd>
 					</div>
 					<div>
-						<dt><?php esc_html_e( 'Google results', 'plan-your-day' ); ?></dt>
+						<dt><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_results_label' ) ); ?></dt>
 						<dd data-plan-summary-results><?php echo esc_html( $planner_state['search_results_label'] ); ?></dd>
 					</div>
 					<div>
-						<dt><?php esc_html_e( 'Google Maps start', 'plan-your-day' ); ?></dt>
+						<dt><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_start_label' ) ); ?></dt>
 						<dd data-plan-summary-handoff-start><?php echo esc_html( $planner_state['handoff_start_label'] ); ?></dd>
 					</div>
 					<div>
-						<dt><?php esc_html_e( 'Map mode', 'plan-your-day' ); ?></dt>
+						<dt><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_map_mode_label' ) ); ?></dt>
 						<dd data-plan-summary-mode><?php echo esc_html( $planner_state['preview_mode_label'] ); ?></dd>
 					</div>
 				</dl>
 
 				<div class="plan-your-day__summary-handoff">
-					<p class="plan-your-day__summary-handoff-label" id="<?php echo esc_attr( $maps_label_id ); ?>"><?php esc_html_e( 'Open in Google Maps', 'plan-your-day' ); ?></p>
+					<p class="plan-your-day__summary-handoff-label" id="<?php echo esc_attr( $maps_label_id ); ?>"><?php echo esc_html( $this->settings->get_frontend_copy_value( 'summary_open_maps_label' ) ); ?></p>
 					<a
 						class="plan-your-day__maps-link plan-your-day__maps-link--summary<?php echo $maps_link_enabled ? '' : ' is-disabled'; ?>"
 						<?php echo $maps_link_enabled ? 'href="' . esc_url( $planner_state['maps_url'] ) . '"' : ''; ?>
@@ -631,15 +629,23 @@ final class PlannerRenderer {
 
 	private function get_start_points(): array {
 		$allowed_modes = $this->settings->get_allowed_start_modes();
-		$choices       = Settings::start_mode_choices();
+		$default_label = '' !== $this->settings->get_default_location_label()
+			? $this->settings->get_default_location_label()
+			: $this->settings->get_frontend_copy_value( 'start_default_location_fallback' );
+		$choices       = [
+			Settings::START_MODE_CURRENT => $this->settings->get_frontend_copy_value( 'start_mode_current_label' ),
+			Settings::START_MODE_DEFAULT => $default_label,
+			Settings::START_MODE_CUSTOM  => $this->settings->get_frontend_copy_value( 'start_mode_custom_label' ),
+		];
 		$descriptions  = [
-			Settings::START_MODE_CURRENT => __( 'Use the configured default location for on-page previews. Google Maps can start from the visitor\'s current location during handoff.', 'plan-your-day' ),
-			Settings::START_MODE_DEFAULT => sprintf(
-				/* translators: %s is the configured default location label. */
-				__( 'Start from %s.', 'plan-your-day' ),
-				$this->settings->get_default_location_label()
+			Settings::START_MODE_CURRENT => $this->settings->get_frontend_copy_value( 'start_mode_current_description' ),
+			Settings::START_MODE_DEFAULT => $this->settings->format_frontend_copy(
+				'start_mode_default_description',
+				[
+					'default_location' => $default_label,
+				]
 			),
-			Settings::START_MODE_CUSTOM  => __( 'Enter a hotel name, landmark, or street address.', 'plan-your-day' ),
+			Settings::START_MODE_CUSTOM  => $this->settings->get_frontend_copy_value( 'start_mode_custom_description' ),
 		];
 		$start_points  = [];
 
@@ -687,51 +693,34 @@ final class PlannerRenderer {
 				'shouldHydrateOnLoad' => $should_hydrate_on_load,
 			],
 			'strings'         => [
-				'requestFailed'       => __( 'The planner request could not be completed. Refresh the page and try again.', 'plan-your-day' ),
-				'resultsUpdated'      => __( 'Results updated.', 'plan-your-day' ),
-				'searchResultsFor'    =>
-					/* translators: %s is a search label. */
-					__( 'Results for %s', 'plan-your-day' ),
-				'categoryResultsExpanded' =>
-					/* translators: %s is a category label. */
-					__( '%s results expanded.', 'plan-your-day' ),
-				'categoryResultsCollapsed' =>
-					/* translators: %s is a category label. */
-					__( '%s results collapsed.', 'plan-your-day' ),
-				'customSearchResultsDescription' => __( 'Custom category search results.', 'plan-your-day' ),
-				'customResultsExpanded' => __( 'Custom search results expanded.', 'plan-your-day' ),
-				'customResultsCollapsed' => __( 'Custom search results collapsed.', 'plan-your-day' ),
-				'tripUpdated'         => __( 'Trip updated.', 'plan-your-day' ),
-				'startingPointUpdated' => __( 'Starting point updated.', 'plan-your-day' ),
-				'startOptionsExpanded' => __( 'Starting point options expanded.', 'plan-your-day' ),
-				'startOptionsCollapsed' => __( 'Starting point options collapsed.', 'plan-your-day' ),
-				'openMapsDisabled'   => __( 'Add at least one waypoint before opening the trip in Google Maps.', 'plan-your-day' ),
-				'viewInGoogleMaps'   => __( 'View in Google Maps', 'plan-your-day' ),
-				'viewPlaceInGoogleMapsLabel' =>
-					/* translators: %s is a place label. */
-					__( 'View %s in Google Maps', 'plan-your-day' ),
-				'addToTrip'          => __( 'Add to trip', 'plan-your-day' ),
-				'addWaypointLabel'   =>
-					/* translators: %s is a place label. */
-					__( 'Add %s to trip', 'plan-your-day' ),
-				'inTrip'             => __( 'In trip', 'plan-your-day' ),
-				'alreadyInTripAria'  =>
-					/* translators: %s is a place label. */
-					__( '%s is already in the trip', 'plan-your-day' ),
-				'tripEmptyHeading'   => __( 'Start building the trip', 'plan-your-day' ),
-				'tripEmptyBody'      => __( 'Search Google by category, then add the exact places you want as walking-trip waypoints.', 'plan-your-day' ),
-				'moveUp'             => __( 'Move up', 'plan-your-day' ),
-				'moveDown'           => __( 'Move down', 'plan-your-day' ),
-				'moveWaypointUpLabel' =>
-					/* translators: %s is a place label. */
-					__( 'Move %s up in the trip', 'plan-your-day' ),
-				'moveWaypointDownLabel' =>
-					/* translators: %s is a place label. */
-					__( 'Move %s down in the trip', 'plan-your-day' ),
-				'removeWaypointLabel' =>
-					/* translators: %s is a place label. */
-					__( 'Remove %s', 'plan-your-day' ),
-				'clearTrip'          => __( 'Clear trip', 'plan-your-day' ),
+				'requestFailed'            => $this->settings->get_frontend_copy_value( 'request_failed' ),
+				'resultsUpdated'           => $this->settings->get_frontend_copy_value( 'results_updated_announcement' ),
+				'searchResultsFor'         => $this->settings->get_frontend_copy_value( 'custom_results_heading' ),
+				'categoryResultsExpanded'  => $this->settings->get_frontend_copy_value( 'category_results_expanded_announcement' ),
+				'categoryResultsCollapsed' => $this->settings->get_frontend_copy_value( 'category_results_collapsed_announcement' ),
+				'customSearchResultsDescription' => $this->settings->get_frontend_copy_value( 'custom_results_description' ),
+				'customResultsExpanded'    => $this->settings->get_frontend_copy_value( 'custom_results_expanded_announcement' ),
+				'customResultsCollapsed'   => $this->settings->get_frontend_copy_value( 'custom_results_collapsed_announcement' ),
+				'tripUpdated'              => $this->settings->get_frontend_copy_value( 'trip_updated_announcement' ),
+				'startingPointUpdated'     => $this->settings->get_frontend_copy_value( 'starting_point_updated_announcement' ),
+				'startOptionsExpanded'     => '',
+				'startOptionsCollapsed'    => '',
+				'openMapsDisabled'         => $this->settings->get_frontend_copy_value( 'open_maps_disabled_announcement' ),
+				'viewInGoogleMaps'         => $this->settings->get_frontend_copy_value( 'view_in_google_maps' ),
+				'viewPlaceInGoogleMapsLabel' => $this->settings->get_frontend_copy_value( 'view_place_in_google_maps_aria' ),
+				'addToTrip'                => $this->settings->get_frontend_copy_value( 'add_to_trip' ),
+				'addWaypointLabel'         => $this->settings->get_frontend_copy_value( 'add_waypoint_aria' ),
+				'inTrip'                   => $this->settings->get_frontend_copy_value( 'in_trip' ),
+				'alreadyInTripAria'        => $this->settings->get_frontend_copy_value( 'already_in_trip_aria' ),
+				'tripEmptyHeading'         => $this->settings->get_frontend_copy_value( 'trip_empty_heading' ),
+				'tripEmptyBody'            => $this->settings->get_frontend_copy_value( 'trip_empty_body' ),
+				'moveUp'                   => $this->settings->get_frontend_copy_value( 'move_up' ),
+				'moveDown'                 => $this->settings->get_frontend_copy_value( 'move_down' ),
+				'moveWaypointUpLabel'      => $this->settings->get_frontend_copy_value( 'move_waypoint_up_aria' ),
+				'moveWaypointDownLabel'    => $this->settings->get_frontend_copy_value( 'move_waypoint_down_aria' ),
+				'removeWaypointLabel'      => $this->settings->get_frontend_copy_value( 'remove_waypoint_label' ),
+				'clearTrip'                => $this->settings->get_frontend_copy_value( 'clear_trip' ),
+				'notSelected'              => $this->settings->get_frontend_copy_value( 'not_selected' ),
 			],
 			'debug'           => defined( 'WP_DEBUG' ) && true === WP_DEBUG,
 			'initialState'    => [

--- a/plugin/plan-your-day/src/Planner/CategoryCatalog.php
+++ b/plugin/plan-your-day/src/Planner/CategoryCatalog.php
@@ -15,20 +15,10 @@ final class CategoryCatalog {
 	}
 
 	public function get_all(): array {
-		$stored_categories = $this->normalize_rows( $this->settings->get_categories() );
-
-		if ( [] !== $stored_categories ) {
-			return $stored_categories;
-		}
-
-		if ( ! $this->settings->use_preset_categories() ) {
-			return [];
-		}
-
-		return $this->normalize_rows( self::preset_rows() );
+		return $this->normalize_rows( $this->settings->get_categories() );
 	}
 
-	public static function preset_rows(): array {
+	public static function default_rows(): array {
 		return [
 			[
 				'slug'        => 'coffee',
@@ -87,6 +77,10 @@ final class CategoryCatalog {
 				'sort_order'  => 70,
 			],
 		];
+	}
+
+	public static function preset_rows(): array {
+		return self::default_rows();
 	}
 
 	private function normalize_rows( array $rows ): array {

--- a/plugin/plan-your-day/src/Planner/DistanceFormatter.php
+++ b/plugin/plan-your-day/src/Planner/DistanceFormatter.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Planner;
 
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
 use Acodebeard\PlanYourDay\Settings\Settings;
 
 defined( 'ABSPATH' ) || exit;
@@ -10,6 +11,11 @@ defined( 'ABSPATH' ) || exit;
 final class DistanceFormatter {
 	private const EARTH_RADIUS_MILES = 3958.8;
 	private const MILES_TO_KILOMETERS = 1.609344;
+	private ?Settings $settings;
+
+	public function __construct( ?Settings $settings = null ) {
+		$this->settings = $settings;
+	}
 
 	public function calculate_miles(
 		float $origin_latitude,
@@ -40,18 +46,20 @@ final class DistanceFormatter {
 
 		if ( $distance < 0.1 ) {
 			if ( '' === $reference_label ) {
-				return sprintf(
-					/* translators: %s is a distance unit abbreviation, such as mi or km. */
-					__( 'Less than 0.1 %s away', 'plan-your-day' ),
-					$unit_label
+				return $this->format_copy(
+					'distance_under_threshold_without_reference',
+					[
+						'unit' => $unit_label,
+					]
 				);
 			}
 
-			return sprintf(
-				/* translators: 1: distance unit abbreviation, 2: starting point label. */
-				__( 'Less than 0.1 %1$s from %2$s', 'plan-your-day' ),
-				$unit_label,
-				$reference_label
+			return $this->format_copy(
+				'distance_under_threshold_with_reference',
+				[
+					'unit'  => $unit_label,
+					'start' => $reference_label,
+				]
 			);
 		}
 
@@ -60,20 +68,30 @@ final class DistanceFormatter {
 			: number_format_i18n( $distance, 1 );
 
 		if ( '' === $reference_label ) {
-			return sprintf(
-				/* translators: 1: rounded distance, 2: distance unit abbreviation. */
-				__( 'Approx. %1$s %2$s away', 'plan-your-day' ),
-				$rounded_distance,
-				$unit_label
+			return $this->format_copy(
+				'distance_approx_without_reference',
+				[
+					'distance' => $rounded_distance,
+					'unit'     => $unit_label,
+				]
 			);
 		}
 
-		return sprintf(
-			/* translators: 1: rounded distance, 2: distance unit abbreviation, 3: starting point label. */
-			__( 'Approx. %1$s %2$s from %3$s', 'plan-your-day' ),
-			$rounded_distance,
-			$unit_label,
-			$reference_label
+		return $this->format_copy(
+			'distance_approx_with_reference',
+			[
+				'distance' => $rounded_distance,
+				'unit'     => $unit_label,
+				'start'    => $reference_label,
+			]
 		);
+	}
+
+	private function format_copy( string $key, array $tokens ): string {
+		if ( $this->settings instanceof Settings ) {
+			return $this->settings->format_frontend_copy( $key, $tokens );
+		}
+
+		return InterfaceCopy::format( InterfaceCopy::default_value( $key ), $tokens );
 	}
 }

--- a/plugin/plan-your-day/src/Planner/PlannerPayloadBuilder.php
+++ b/plugin/plan-your-day/src/Planner/PlannerPayloadBuilder.php
@@ -3,14 +3,23 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Planner;
 
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
+use Acodebeard\PlanYourDay\Settings\Settings;
+
 defined( 'ABSPATH' ) || exit;
 
 final class PlannerPayloadBuilder {
+	private ?Settings $settings;
+
+	public function __construct( ?Settings $settings = null ) {
+		$this->settings = $settings;
+	}
+
 	public function build_browse_payload( array $planner_state ): array {
 		return [
 			'categoryKey'        => $planner_state['category_key'],
 			'categorySearch'     => $planner_state['category_search'],
-			'categoryLabel'      => $planner_state['has_search'] ? $planner_state['active_search_label'] : __( 'Not selected', 'plan-your-day' ),
+			'categoryLabel'      => $planner_state['has_search'] ? $planner_state['active_search_label'] : $this->copy_value( 'not_selected' ),
 			'hasCategory'        => $planner_state['has_category'],
 			'hasCategories'      => $planner_state['has_categories'],
 			'hasSearch'          => $planner_state['has_search'],
@@ -26,7 +35,7 @@ final class PlannerPayloadBuilder {
 		return [
 			'categoryKey'         => $planner_state['category_key'],
 			'categorySearch'      => $planner_state['category_search'],
-			'categoryLabel'       => $planner_state['has_search'] ? $planner_state['active_search_label'] : __( 'Not selected', 'plan-your-day' ),
+			'categoryLabel'       => $planner_state['has_search'] ? $planner_state['active_search_label'] : $this->copy_value( 'not_selected' ),
 			'hasSearch'           => $planner_state['has_search'],
 			'selectedWaypointIds' => array_values( $planner_state['selected_waypoint_ids'] ),
 			'tripWaypoints'       => array_values( $planner_state['trip_waypoints'] ),
@@ -48,46 +57,54 @@ final class PlannerPayloadBuilder {
 	public function get_empty_results_state( array $planner_state ): array {
 		if ( ! empty( $planner_state['search_results_error'] ) ) {
 			return [
-				'heading' => __( 'Google results unavailable', 'plan-your-day' ),
-				'body'    => __( 'Google place results are unavailable right now. Try again later or open the Google Maps handoff link.', 'plan-your-day' ),
+				'heading' => $this->copy_value( 'search_results_unavailable_heading' ),
+				'body'    => $this->copy_value( 'search_results_unavailable_body' ),
 			];
 		}
 
 		if ( ! $planner_state['has_search'] ) {
 			return [
-				'heading' => __( 'Search for any category', 'plan-your-day' ),
+				'heading' => $this->copy_value( 'search_results_prompt_heading' ),
 				'body'    => $planner_state['has_categories']
-					? __( 'Use the search box or choose a preset category to load real place results.', 'plan-your-day' )
-					: __( 'Use the search box to load real place results.', 'plan-your-day' ),
+					? $this->copy_value( 'search_results_prompt_body_with_categories' )
+					: $this->copy_value( 'search_results_prompt_body_no_categories' ),
 			];
 		}
 
 		return [
-			'heading' => __( 'No matching Google results', 'plan-your-day' ),
-			'body'    => __( 'Try a different search or change the starting area.', 'plan-your-day' ),
+			'heading' => $this->copy_value( 'no_matching_results_heading' ),
+			'body'    => $this->copy_value( 'no_matching_results_body' ),
 		];
 	}
 
 	public function get_empty_preview_state( array $planner_state ): array {
 		if ( ! $planner_state['has_search'] && ! $planner_state['has_trip'] ) {
 			return [
-				'heading' => __( 'Start with a category search', 'plan-your-day' ),
+				'heading' => $this->copy_value( 'preview_prompt_heading' ),
 				'body'    => $planner_state['has_categories']
-					? __( 'Use the search box or choose a preset category to load Google results, then add the places you want to turn into trip waypoints.', 'plan-your-day' )
-					: __( 'Use the search box to load Google results, then add the places you want to turn into trip waypoints.', 'plan-your-day' ),
+					? $this->copy_value( 'preview_prompt_body_with_categories' )
+					: $this->copy_value( 'preview_prompt_body_no_categories' ),
 			];
 		}
 
 		if ( $planner_state['has_search'] && ! $planner_state['has_trip'] ) {
 			return [
-				'heading' => __( 'Search preview unavailable', 'plan-your-day' ),
-				'body'    => __( 'The on-page map preview needs a valid Google Maps Embed API key. The Google Maps search link still works.', 'plan-your-day' ),
+				'heading' => $this->copy_value( 'search_preview_unavailable_heading' ),
+				'body'    => $this->copy_value( 'search_preview_unavailable_body' ),
 			];
 		}
 
 		return [
-			'heading' => __( 'Trip preview unavailable', 'plan-your-day' ),
-			'body'    => __( 'The on-page trip preview needs a valid Google Maps Embed API key. The Google Maps handoff link still works.', 'plan-your-day' ),
+			'heading' => $this->copy_value( 'trip_preview_unavailable_heading' ),
+			'body'    => $this->copy_value( 'trip_preview_unavailable_body' ),
 		];
+	}
+
+	private function copy_value( string $key ): string {
+		if ( $this->settings instanceof Settings ) {
+			return $this->settings->get_frontend_copy_value( $key );
+		}
+
+		return InterfaceCopy::default_value( $key );
 	}
 }

--- a/plugin/plan-your-day/src/Planner/PlannerStateBuilder.php
+++ b/plugin/plan-your-day/src/Planner/PlannerStateBuilder.php
@@ -85,10 +85,10 @@ final class PlannerStateBuilder {
 		$resolved_waypoints   = [];
 		$iframe_src           = '';
 		$maps_url             = '';
-		$maps_link_label      = __( 'Explore in Google Maps', 'plan-your-day' );
-		$preview_mode_label   = __( 'Google place search', 'plan-your-day' );
-		$overview             = __( 'Search for any category or pick one below to load Google results, then add exact places to your trip.', 'plan-your-day' );
-		$trip_count_label     = __( 'Trip not started', 'plan-your-day' );
+		$maps_link_label      = $this->settings->get_frontend_copy_value( 'maps_link_label_search' );
+		$preview_mode_label   = $this->settings->get_frontend_copy_value( 'preview_mode_label_search' );
+		$overview             = $this->settings->get_frontend_copy_value( 'overview_initial_with_categories' );
+		$trip_count_label     = $this->settings->get_frontend_copy_value( 'trip_not_started_label' );
 
 		if ( $include_results && '' !== $search_query ) {
 			$search_origin_coordinates = $this->geocode_search_area( $search_context['search_area'] );
@@ -140,29 +140,26 @@ final class PlannerStateBuilder {
 		$has_trip             = [] !== $trip_waypoints;
 		$search_results_count = count( $search_results );
 		$search_results_label = $has_search
-			? sprintf(
-				/* translators: %d is the number of Google results. */
-				_n( '%d Google result', '%d Google results', $search_results_count, 'plan-your-day' ),
-				$search_results_count
-			)
-			: __( 'No Google results loaded', 'plan-your-day' );
+			? $this->count_copy( 'search_results_count_single', 'search_results_count_plural', $search_results_count )
+			: $this->settings->get_frontend_copy_value( 'no_results_loaded_label' );
 
 		if ( $has_trip ) {
 			$route_state = $this->build_trip_route_state( $trip_waypoints, $resolved_waypoints, $search_context );
 			$messages    = array_merge( $messages, $route_state['messages'] );
 
 			$trip_count_label   = $route_state['trip_count_label'];
-			$preview_mode_label = __( 'Walking directions', 'plan-your-day' );
-			$maps_link_label    = __( 'Open trip in Google Maps', 'plan-your-day' );
+			$preview_mode_label = $this->settings->get_frontend_copy_value( 'preview_mode_label_trip' );
+			$maps_link_label    = $this->settings->get_frontend_copy_value( 'maps_link_label_trip' );
 			$overview           = $route_state['overview'];
 			$iframe_src         = $route_state['iframe_src'];
 			$maps_url           = $route_state['maps_url'];
 		} elseif ( $has_search ) {
-			$overview = sprintf(
-				/* translators: 1: search label, 2: start summary. */
-				__( 'Browsing Google results for %1$s near %2$s. Add any result to start building a walking trip.', 'plan-your-day' ),
-				$active_search_label,
-				$search_context['handoff_summary']
+			$overview = $this->settings->format_frontend_copy(
+				'overview_browse_search',
+				[
+					'search' => $active_search_label,
+					'start'  => $search_context['handoff_summary'],
+				]
 			);
 
 			if ( $this->settings->is_map_preview_enabled() ) {
@@ -174,7 +171,7 @@ final class PlannerStateBuilder {
 				if ( '' === $iframe_src ) {
 					$messages[] = [
 						'type' => 'warning',
-						'text' => __( 'Add a valid Google Maps Embed API key before relying on the on-site search preview.', 'plan-your-day' ),
+						'text' => $this->settings->get_frontend_copy_value( 'search_preview_key_warning' ),
 					];
 				}
 			}
@@ -183,7 +180,7 @@ final class PlannerStateBuilder {
 				$maps_url = $this->map_url_builder->build_search_handoff_url( $handoff_search_query );
 			}
 		} elseif ( ! $has_categories ) {
-			$overview = __( 'Search for any category to load Google results, then add exact places to your trip.', 'plan-your-day' );
+			$overview = $this->settings->get_frontend_copy_value( 'overview_initial_no_categories' );
 		}
 
 		return [
@@ -291,7 +288,7 @@ final class PlannerStateBuilder {
 				$is_partial = true;
 				$messages[] = [
 					'type' => 'warning',
-					'text' => __( 'The trip preview stopped loading more places before the request timed out. Try again or remove a few stops.', 'plan-your-day' ),
+					'text' => $this->settings->get_frontend_copy_value( 'trip_timeout_warning' ),
 				];
 				DebugLogger::log(
 					'planner.trip_waypoints.deadline_reached',
@@ -321,14 +318,14 @@ final class PlannerStateBuilder {
 				);
 				$messages[] = [
 					'type' => 'warning',
-					'text' => __( 'One selected place could not be loaded from Google and was skipped.', 'plan-your-day' ),
+					'text' => $this->settings->get_frontend_copy_value( 'trip_place_skipped_warning' ),
 				];
 
 				if ( null !== $max_failures && $failure_count >= $max_failures ) {
 					$is_partial = true;
 					$messages[] = [
 						'type' => 'warning',
-						'text' => __( 'The trip preview stopped loading more places after repeated Google place errors. Try again later or remove any invalid stops.', 'plan-your-day' ),
+						'text' => $this->settings->get_frontend_copy_value( 'trip_repeated_errors_warning' ),
 					];
 					DebugLogger::log(
 						'planner.trip_waypoints.failure_limit_reached',
@@ -374,8 +371,8 @@ final class PlannerStateBuilder {
 	private function build_unresolved_trip_waypoint( string $waypoint_id ): array {
 		return [
 			'id'         => $waypoint_id,
-			'label'      => __( 'Selected place needs attention', 'plan-your-day' ),
-			'address'    => __( 'Google could not load this place right now. It is still selected and can be retried, moved, or removed.', 'plan-your-day' ),
+			'label'      => $this->settings->get_frontend_copy_value( 'unresolved_waypoint_label' ),
+			'address'    => $this->settings->get_frontend_copy_value( 'unresolved_waypoint_address' ),
 			'unresolved' => true,
 		];
 	}
@@ -433,27 +430,18 @@ final class PlannerStateBuilder {
 	private function build_trip_route_state( array $trip_waypoints, array $resolved_waypoints, array $search_context ): array {
 		$messages            = [];
 		$trip_count          = count( $trip_waypoints );
-		$trip_count_label    = sprintf(
-			/* translators: %d is the number of selected waypoints. */
-			_n( '%d waypoint selected', '%d waypoints selected', $trip_count, 'plan-your-day' ),
-			$trip_count
-		);
+		$trip_count_label    = $this->count_copy( 'trip_count_single', 'trip_count_plural', $trip_count );
 		$route_description   = [] !== $resolved_waypoints
 			? $this->build_route_description( $resolved_waypoints, $search_context['handoff_summary'] )
-			: __( 'One or more selected places still need to load before the walking trip can be previewed.', 'plan-your-day' );
-		$overview            = sprintf(
-			/* translators: 1: waypoint count label, 2: route description. */
-			__( '%1$s. %2$s', 'plan-your-day' ),
-			$trip_count_label,
-			$route_description
-		);
+			: $this->settings->get_frontend_copy_value( 'trip_route_unresolved' );
+		$overview            = $this->build_trip_overview( $trip_count_label, $route_description );
 		$iframe_src          = '';
 		$maps_url            = '';
 
 		if ( count( $resolved_waypoints ) !== count( $trip_waypoints ) ) {
 			$messages[] = [
 				'type' => 'warning',
-				'text' => __( 'The trip preview and Google Maps handoff will stay unavailable until every selected place loads successfully.', 'plan-your-day' ),
+				'text' => $this->settings->get_frontend_copy_value( 'trip_unavailable_until_loaded_warning' ),
 			];
 
 			return [
@@ -475,7 +463,7 @@ final class PlannerStateBuilder {
 			if ( '' === $iframe_src ) {
 				$messages[] = [
 					'type' => 'warning',
-					'text' => __( 'Add a valid Google Maps Embed API key before relying on the on-site trip preview.', 'plan-your-day' ),
+					'text' => $this->settings->get_frontend_copy_value( 'trip_preview_key_warning' ),
 				];
 			}
 		}
@@ -501,11 +489,12 @@ final class PlannerStateBuilder {
 		$intermediates = count( $trip_waypoints ) > 1 ? array_slice( $trip_waypoints, 0, -1 ) : [];
 
 		if ( [] === $intermediates ) {
-			return sprintf(
-				/* translators: 1: start summary, 2: destination label. */
-				__( 'Walking directions run from %1$s to %2$s.', 'plan-your-day' ),
-				$handoff_summary,
-				$destination['label']
+			return $this->settings->format_frontend_copy(
+				'route_description_direct',
+				[
+					'start'       => $handoff_summary,
+					'destination' => (string) $destination['label'],
+				]
 			);
 		}
 
@@ -520,12 +509,13 @@ final class PlannerStateBuilder {
 				)
 			);
 
-		return sprintf(
-			/* translators: 1: start summary, 2: destination label, 3: via stop labels. */
-			__( 'Walking directions run from %1$s to %2$s via %3$s.', 'plan-your-day' ),
-			$handoff_summary,
-			$destination['label'],
-			$via_label
+		return $this->settings->format_frontend_copy(
+			'route_description_via',
+			[
+				'start'       => $handoff_summary,
+				'destination' => (string) $destination['label'],
+				'via'         => $via_label,
+			]
 		);
 	}
 
@@ -551,21 +541,52 @@ final class PlannerStateBuilder {
 		}
 
 		if ( 2 === $label_count ) {
-			return sprintf(
-				/* translators: 1: first label, 2: second label. */
-				__( '%1$s and %2$s', 'plan-your-day' ),
-				$labels[0],
-				$labels[1]
+			return $this->settings->format_frontend_copy(
+				'label_list_pair',
+				[
+					'first'  => $labels[0],
+					'second' => $labels[1],
+				]
 			);
 		}
 
 		$last_label = array_pop( $labels );
 
-		return sprintf(
-			/* translators: 1: comma-separated label list, 2: final label. */
-			__( '%1$s, and %2$s', 'plan-your-day' ),
-			implode( ', ', $labels ),
-			$last_label
+		return $this->settings->format_frontend_copy(
+			'label_list_many',
+			[
+				'list' => implode( ', ', $labels ),
+				'last' => (string) $last_label,
+			]
+		);
+	}
+
+	private function count_copy( string $single_key, string $plural_key, int $count ): string {
+		$template_key = 1 === $count ? $single_key : $plural_key;
+
+		return $this->settings->format_frontend_copy(
+			$template_key,
+			[
+				'count' => (string) $count,
+			]
+		);
+	}
+
+	private function build_trip_overview( string $trip_count_label, string $route_description ): string {
+		$template = $this->settings->get_frontend_copy_value( 'trip_overview_template' );
+
+		if ( '' === $template ) {
+			return '';
+		}
+
+		return trim(
+			$this->settings->format_frontend_copy(
+				'trip_overview_template',
+				[
+					'trip_count'        => $trip_count_label,
+					'route_description' => $route_description,
+				]
+			)
 		);
 	}
 }

--- a/plugin/plan-your-day/src/Planner/StartContextResolver.php
+++ b/plugin/plan-your-day/src/Planner/StartContextResolver.php
@@ -38,7 +38,7 @@ final class StartContextResolver {
 		}
 
 		if ( '' === $default_location_label ) {
-			$default_location_label = __( 'Default location', 'plan-your-day' );
+			$default_location_label = $this->settings->get_frontend_copy_value( 'start_default_location_fallback' );
 		}
 
 		$preview_start_label = $default_location_label;
@@ -48,17 +48,17 @@ final class StartContextResolver {
 		$directions_origin   = $default_address;
 		$messages            = [];
 		$use_current_handoff = false;
-		$start_note_text     = __( 'The on-page results, preview, and Google Maps handoff use the configured default starting point.', 'plan-your-day' );
+		$start_note_text     = $this->settings->get_frontend_copy_value( 'start_default_note' );
 
 		if ( Settings::START_MODE_CURRENT === $start_mode ) {
-			$handoff_start_label = __( 'Current location', 'plan-your-day' );
-			$handoff_summary     = __( 'your current location', 'plan-your-day' );
+			$handoff_start_label = $this->settings->get_frontend_copy_value( 'start_current_handoff_label' );
+			$handoff_summary     = $this->settings->get_frontend_copy_value( 'start_current_handoff_summary' );
 			$directions_origin   = null;
 			$use_current_handoff = true;
-			$start_note_text     = __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', 'plan-your-day' );
+			$start_note_text     = $this->settings->get_frontend_copy_value( 'start_current_note' );
 			$messages[]          = [
 				'type' => 'note',
-				'text' => __( 'The on-page results and preview use the configured default starting point. Google Maps will start from the visitor\'s current location during handoff.', 'plan-your-day' ),
+				'text' => $this->settings->get_frontend_copy_value( 'start_current_message' ),
 			];
 		} elseif ( Settings::START_MODE_CUSTOM === $start_mode && '' !== $custom_start ) {
 			$search_area         = $custom_start;
@@ -66,14 +66,14 @@ final class StartContextResolver {
 			$handoff_start_label = $custom_start;
 			$handoff_summary     = $custom_start;
 			$directions_origin   = $custom_start;
-			$start_note_text     = __( 'The on-page results, preview, and Google Maps handoff all use the custom starting point.', 'plan-your-day' );
+			$start_note_text     = $this->settings->get_frontend_copy_value( 'start_custom_note' );
 		} elseif ( Settings::START_MODE_CUSTOM === $start_mode ) {
-			$handoff_start_label = __( 'Default location fallback', 'plan-your-day' );
-			$handoff_summary     = __( 'the default location until a custom starting point is provided', 'plan-your-day' );
-			$start_note_text     = __( 'Add a custom address to replace the default fallback for search results, the route preview, and the Google Maps handoff.', 'plan-your-day' );
+			$handoff_start_label = $this->settings->get_frontend_copy_value( 'start_default_fallback_label' );
+			$handoff_summary     = $this->settings->get_frontend_copy_value( 'start_default_fallback_summary' );
+			$start_note_text     = $this->settings->get_frontend_copy_value( 'start_custom_missing_note' );
 			$messages[]          = [
 				'type' => 'warning',
-				'text' => __( 'Add a custom address to replace the default fallback before finalizing the trip start.', 'plan-your-day' ),
+				'text' => $this->settings->get_frontend_copy_value( 'start_custom_missing_message' ),
 			];
 		}
 

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -69,12 +69,12 @@ final class Plugin {
 		$this->request_state_parser     = new RequestStateParser( $this->waypoint_list );
 		$this->start_context_resolver   = new StartContextResolver( $this->settings );
 		$this->map_url_builder          = new MapUrlBuilder();
-		$this->distance_formatter       = new DistanceFormatter();
+		$this->distance_formatter       = new DistanceFormatter( $this->settings );
 		$this->request_origin_validator = new RequestOriginValidator();
 		$this->visitor_token_manager    = new VisitorTokenManager();
 		$this->client_ip_resolver       = new ClientIpResolver( $this->settings );
 		$this->rate_limiter             = new RateLimiter( $this->settings, $this->client_ip_resolver );
-		$this->planner_payload_builder  = new PlannerPayloadBuilder();
+		$this->planner_payload_builder  = new PlannerPayloadBuilder( $this->settings );
 		$this->settings_page            = new SettingsPage(
 			$this->settings,
 			$this->google_api_cache,
@@ -97,17 +97,20 @@ final class Plugin {
 			$this->planner_payload_builder,
 			$this->request_origin_validator,
 			$this->visitor_token_manager,
-			$this->rate_limiter
+			$this->rate_limiter,
+			$this->settings
 		);
 	}
 
 	public function init(): void {
 		add_action( 'init', [ $this, 'load_textdomain' ], 0 );
+		add_action( 'init', [ $this->settings, 'maybe_upgrade' ], 1 );
 		add_action( 'init', [ $this->planner_shortcode, 'register' ] );
 		add_action( 'rest_api_init', [ $this->planner_routes, 'register' ] );
 		add_action( 'wp_enqueue_scripts', [ $this->frontend_assets, 'register' ] );
 		add_action( 'admin_init', [ $this->settings, 'register' ] );
 		add_action( 'admin_menu', [ $this->settings_page, 'register' ] );
+		add_action( 'admin_enqueue_scripts', [ $this->settings_page, 'enqueue_assets' ] );
 		add_action( 'admin_notices', [ $this->settings_page, 'render_missing_required_settings_notice' ] );
 		add_action( 'admin_post_plan_your_day_clear_google_cache', [ $this->settings_page, 'handle_clear_google_cache' ] );
 		add_action( 'admin_post_plan_your_day_clear_google_cache_scope', [ $this->settings_page, 'handle_clear_google_cache_scope' ] );

--- a/plugin/plan-your-day/src/Rest/PlannerRoutes.php
+++ b/plugin/plan-your-day/src/Rest/PlannerRoutes.php
@@ -9,6 +9,7 @@ use Acodebeard\PlanYourDay\Planner\RequestStateParser;
 use Acodebeard\PlanYourDay\Security\RateLimiter;
 use Acodebeard\PlanYourDay\Security\RequestOriginValidator;
 use Acodebeard\PlanYourDay\Security\VisitorTokenManager;
+use Acodebeard\PlanYourDay\Settings\Settings;
 use Acodebeard\PlanYourDay\Support\DebugLogger;
 use WP_Error;
 use WP_REST_Request;
@@ -31,6 +32,7 @@ final class PlannerRoutes {
 	private RequestOriginValidator $request_origin_validator;
 	private VisitorTokenManager $visitor_token_manager;
 	private RateLimiter $rate_limiter;
+	private ?Settings $settings;
 
 	public function __construct(
 		RequestStateParser $request_state_parser,
@@ -38,7 +40,8 @@ final class PlannerRoutes {
 		PlannerPayloadBuilder $planner_payload_builder,
 		RequestOriginValidator $request_origin_validator,
 		VisitorTokenManager $visitor_token_manager,
-		RateLimiter $rate_limiter
+		RateLimiter $rate_limiter,
+		?Settings $settings = null
 	) {
 		$this->request_state_parser     = $request_state_parser;
 		$this->planner_state_builder    = $planner_state_builder;
@@ -46,6 +49,7 @@ final class PlannerRoutes {
 		$this->request_origin_validator = $request_origin_validator;
 		$this->visitor_token_manager    = $visitor_token_manager;
 		$this->rate_limiter             = $rate_limiter;
+		$this->settings                 = $settings;
 	}
 
 	public function register(): void {
@@ -151,7 +155,7 @@ final class PlannerRoutes {
 		if ( ! $this->request_origin_validator->is_same_site_request( $_SERVER ) ) {
 			$error = new WP_Error(
 				'plan_your_day_invalid_origin',
-				__( 'The planner request could not be verified. Refresh the page and try again.', 'plan-your-day' ),
+				$this->request_verification_failed_message(),
 				[
 					'status' => 403,
 				]
@@ -177,7 +181,7 @@ final class PlannerRoutes {
 		if ( ! $this->visitor_token_manager->validate_endpoint_token( $endpoint_token ) ) {
 			$error = new WP_Error(
 				'plan_your_day_invalid_token',
-				__( 'The planner request could not be verified. Refresh the page and try again.', 'plan-your-day' ),
+				$this->request_verification_failed_message(),
 				[
 					'status' => 403,
 				]
@@ -219,6 +223,12 @@ final class PlannerRoutes {
 			'trip_waypoint_place_details_timeout' => self::PUBLIC_TRIP_WAYPOINT_PLACE_DETAILS_TIMEOUT,
 			'trip_waypoint_max_failures'         => self::PUBLIC_TRIP_WAYPOINT_MAX_FAILURES,
 		];
+	}
+
+	private function request_verification_failed_message(): string {
+		return $this->settings instanceof Settings
+			? $this->settings->get_frontend_copy_value( 'request_verification_failed' )
+			: __( 'The planner request could not be verified. Refresh the page and try again.', 'plan-your-day' );
 	}
 
 	private function get_rate_limit_cost( string $scope, array $request_state ): int {

--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -162,7 +162,7 @@ final class RateLimiter {
 	private function rate_limited_error(): WP_Error {
 		return new WP_Error(
 			'plan_your_day_rate_limited',
-			__( 'Planner requests are temporarily limited. Please wait a minute and try again.', 'plan-your-day' ),
+			$this->settings->get_frontend_copy_value( 'rate_limited' ),
 			[
 				'status' => 429,
 			]

--- a/plugin/plan-your-day/src/Settings/Settings.php
+++ b/plugin/plan-your-day/src/Settings/Settings.php
@@ -3,9 +3,13 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Settings;
 
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
+use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+
 defined( 'ABSPATH' ) || exit;
 
 final class Settings {
+	private const EDITABLE_CATEGORY_SCHEMA_VERSION = 2;
 	public const OPTION_NAME = 'plan_your_day_settings';
 	public const OPTION_GROUP = 'plan_your_day_settings';
 	public const PAGE_SLUG = 'plan-your-day';
@@ -49,7 +53,12 @@ final class Settings {
 			'google_geocoding_cache_ttl'     => 86400,
 			'rate_limit_per_minute'           => 60,
 			'trusted_proxy_cidrs'             => '',
+			'interface_copy'                  => InterfaceCopy::defaults(),
 		];
+	}
+
+	public static function default_categories(): array {
+		return self::sanitize_categories( CategoryCatalog::default_rows() );
 	}
 
 	public static function start_mode_choices(): array {
@@ -113,6 +122,7 @@ final class Settings {
 			'google_geocoding_cache_ttl'     => self::sanitize_cache_ttl( $raw_settings['google_geocoding_cache_ttl'] ?? 86400 ),
 			'rate_limit_per_minute'           => self::sanitize_integer( $raw_settings['rate_limit_per_minute'] ?? $defaults['rate_limit_per_minute'], 1, 600, $defaults['rate_limit_per_minute'] ),
 			'trusted_proxy_cidrs'             => self::sanitize_trusted_proxy_cidrs( $raw_settings['trusted_proxy_cidrs'] ?? $defaults['trusted_proxy_cidrs'] ),
+			'interface_copy'                  => InterfaceCopy::sanitize( $raw_settings['interface_copy'] ?? $defaults['interface_copy'] ),
 		];
 	}
 
@@ -366,6 +376,31 @@ final class Settings {
 		$this->cached_settings = null;
 	}
 
+	public function maybe_upgrade(): void {
+		$current_schema_version = (int) get_option( 'plan_your_day_schema_version', 0 );
+
+		if ( $current_schema_version >= self::EDITABLE_CATEGORY_SCHEMA_VERSION ) {
+			return;
+		}
+
+		$this->seed_default_categories_if_needed();
+		update_option( 'plan_your_day_schema_version', self::EDITABLE_CATEGORY_SCHEMA_VERSION );
+	}
+
+	public function seed_default_categories_if_needed(): bool {
+		$settings = get_option( self::OPTION_NAME, [] );
+		$settings = is_array( $settings ) ? $settings : [];
+
+		if ( ! $this->should_seed_default_categories( $settings ) ) {
+			return false;
+		}
+
+		$settings['categories'] = self::default_categories();
+		update_option( self::OPTION_NAME, self::sanitize( array_merge( self::defaults(), $settings ) ) );
+
+		return true;
+	}
+
 	public function get_missing_required_settings(): array {
 		$settings = $this->get_all();
 		$missing  = [];
@@ -457,10 +492,25 @@ final class Settings {
 		return $settings['use_preset_categories'];
 	}
 
-	public function get_categories(): array {
+	public function get_saved_categories(): array {
 		$settings = $this->get_all();
 
 		return is_array( $settings['categories'] ) ? array_values( $settings['categories'] ) : [];
+	}
+
+	public function get_categories(): array {
+		$settings   = $this->get_all();
+		$categories = $this->get_saved_categories();
+
+		if ( [] !== $categories ) {
+			return $categories;
+		}
+
+		if ( ! $settings['use_preset_categories'] ) {
+			return [];
+		}
+
+		return self::default_categories();
 	}
 
 	public function get_google_maps_embed_api_key(): string {
@@ -518,5 +568,30 @@ final class Settings {
 		$cidrs    = preg_split( '/\r\n|\r|\n/', $settings['trusted_proxy_cidrs'] );
 
 		return is_array( $cidrs ) ? array_values( array_filter( $cidrs ) ) : [];
+	}
+
+	public function get_frontend_copy(): array {
+		$settings = $this->get_all();
+
+		return InterfaceCopy::resolve_values( $settings['interface_copy'] ?? [] );
+	}
+
+	public function get_frontend_copy_value( string $key ): string {
+		$copy = $this->get_frontend_copy();
+
+		return isset( $copy[ $key ] ) ? (string) $copy[ $key ] : InterfaceCopy::default_value( $key );
+	}
+
+	public function format_frontend_copy( string $key, array $tokens = [] ): string {
+		return InterfaceCopy::format( $this->get_frontend_copy_value( $key ), $tokens );
+	}
+
+	private function should_seed_default_categories( array $settings ): bool {
+		$saved_categories = self::sanitize_categories( $settings['categories'] ?? [] );
+		$use_fallback     = array_key_exists( 'use_preset_categories', $settings )
+			? self::sanitize_boolean( $settings['use_preset_categories'] )
+			: self::defaults()['use_preset_categories'];
+
+		return [] === $saved_categories && $use_fallback;
 	}
 }

--- a/plugin/plan-your-day/tests/ActivatorTest.php
+++ b/plugin/plan-your-day/tests/ActivatorTest.php
@@ -26,7 +26,7 @@ namespace Acodebeard\PlanYourDay\Tests {
 			}
 
 			if ( ! defined( 'PLAN_YOUR_DAY_SCHEMA_VERSION' ) ) {
-				define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 1 );
+				define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 2 );
 			}
 
 			if ( ! defined( 'PLAN_YOUR_DAY_LEGACY_CONFIG_FILE' ) ) {
@@ -65,7 +65,7 @@ namespace Acodebeard\PlanYourDay\Tests {
 			$settings = get_option( Settings::OPTION_NAME );
 
 			self::assertSame( 'test-version', get_option( 'plan_your_day_version' ) );
-			self::assertSame( 1, get_option( 'plan_your_day_schema_version' ) );
+			self::assertSame( 2, get_option( 'plan_your_day_schema_version' ) );
 			self::assertSame( 'Harbor Start', $settings['default_location_label'] );
 			self::assertSame( '123 Ocean View Ave', $settings['default_location_address'] );
 			self::assertSame( '19.639994', $settings['default_location_latitude'] );
@@ -76,6 +76,14 @@ namespace Acodebeard\PlanYourDay\Tests {
 			self::assertSame( 'places-key_456', $settings['google_places_api_key'] );
 			self::assertSame( 'geocode-key_789', $settings['google_geocoding_api_key'] );
 			self::assertSame( 'beaches', $settings['categories'][0]['slug'] ?? null );
+		}
+
+		public function test_activate_seeds_default_categories_when_no_legacy_categories_are_available(): void {
+			Activator::activate();
+
+			$settings = get_option( Settings::OPTION_NAME );
+
+			self::assertSame( Settings::default_categories(), $settings['categories'] ?? [] );
 		}
 
 		public function test_activate_does_not_overwrite_existing_plugin_settings(): void {

--- a/plugin/plan-your-day/tests/CategoryCatalogTest.php
+++ b/plugin/plan-your-day/tests/CategoryCatalogTest.php
@@ -1,0 +1,91 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+use Acodebeard\PlanYourDay\Settings\Settings;
+use PHPUnit\Framework\TestCase;
+
+final class CategoryCatalogTest extends TestCase {
+	protected function setUp(): void {
+		$GLOBALS['plan_your_day_test_options'] = [];
+		$GLOBALS['plan_your_day_test_actions'] = [];
+		$GLOBALS['plan_your_day_test_option_reads'] = [];
+	}
+
+	public function test_get_all_returns_built_in_starter_categories_when_saved_list_is_empty(): void {
+		update_option( Settings::OPTION_NAME, Settings::defaults() );
+
+		$settings = new Settings();
+		$catalog  = new CategoryCatalog( $settings );
+
+		self::assertSame(
+			[ 'coffee', 'food', 'shopping', 'outdoors', 'history-culture', 'scenic', 'activities' ],
+			array_keys( $catalog->get_all() )
+		);
+	}
+
+	public function test_get_all_returns_only_enabled_saved_categories_in_sort_order(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'categories' => Settings::sanitize_categories(
+						[
+							[
+								'label'       => 'Dessert',
+								'description' => 'Sweet stops',
+								'text_query'  => 'dessert',
+								'slug'        => 'dessert',
+								'enabled'     => true,
+								'sort_order'  => 30,
+							],
+							[
+								'label'       => 'Tea',
+								'description' => 'Tea houses',
+								'text_query'  => 'tea houses',
+								'slug'        => 'tea',
+								'enabled'     => true,
+								'sort_order'  => 10,
+							],
+							[
+								'label'       => 'Hidden',
+								'description' => 'Should not render',
+								'text_query'  => 'hidden',
+								'slug'        => 'hidden',
+								'enabled'     => false,
+								'sort_order'  => 20,
+							],
+						]
+					),
+				]
+			)
+		);
+
+		$settings = new Settings();
+		$catalog  = new CategoryCatalog( $settings );
+
+		self::assertSame( [ 'tea', 'dessert' ], array_keys( $catalog->get_all() ) );
+		self::assertSame( 'Tea', $catalog->get_all()['tea']['label'] ?? null );
+		self::assertArrayNotHasKey( 'hidden', $catalog->get_all() );
+	}
+
+	public function test_get_all_returns_empty_when_saved_list_is_empty_and_fallback_is_disabled(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'use_preset_categories' => false,
+				]
+			)
+		);
+
+		$settings = new Settings();
+		$catalog  = new CategoryCatalog( $settings );
+
+		self::assertSame( [], $catalog->get_all() );
+	}
+}

--- a/plugin/plan-your-day/tests/InitialPlannerHydrationTest.php
+++ b/plugin/plan-your-day/tests/InitialPlannerHydrationTest.php
@@ -81,4 +81,32 @@ final class InitialPlannerHydrationTest extends TestCase {
 		self::assertSame( 'Loading trip preview', $planner_state['preview_empty_state']['heading'] );
 		self::assertSame( 'Loading planner state through a verified request.', $planner_state['messages'][0]['text'] );
 	}
+
+	public function test_apply_loading_placeholders_uses_custom_copy_overrides(): void {
+		$planner_state = InitialPlannerHydration::apply_loading_placeholders(
+			[
+				'has_search'            => true,
+				'selected_waypoint_ids' => [],
+				'search_results_label'  => '',
+				'overview'              => '',
+				'preview_mode_label'    => '',
+				'messages'              => [],
+			],
+			[
+				'hydration_loading_message' => 'Loading saved planner state.',
+				'loading_results_label'     => 'Loading places...',
+				'loading_results_heading'   => 'Loading places',
+				'loading_results_body'      => 'Saved places are loading now.',
+				'loading_search_preview_mode' => 'Loading map preview',
+				'loading_search_preview_heading' => 'Loading map preview',
+				'loading_search_preview_body' => 'Saved map preview is loading now.',
+			]
+		);
+
+		self::assertSame( 'Loading places...', $planner_state['search_results_label'] );
+		self::assertSame( 'Loading places', $planner_state['results_empty_state']['heading'] );
+		self::assertSame( 'Saved places are loading now.', $planner_state['overview'] );
+		self::assertSame( 'Loading map preview', $planner_state['preview_mode_label'] );
+		self::assertSame( 'Loading saved planner state.', $planner_state['messages'][0]['text'] );
+	}
 }

--- a/plugin/plan-your-day/tests/InterfaceCopyTest.php
+++ b/plugin/plan-your-day/tests/InterfaceCopyTest.php
@@ -1,0 +1,42 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Tests;
+
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
+use PHPUnit\Framework\TestCase;
+
+final class InterfaceCopyTest extends TestCase {
+	public function test_sanitize_keeps_optional_blank_and_falls_back_required_blank_values(): void {
+		$sanitized = InterfaceCopy::sanitize(
+			[
+				'hero_title'                  => '   ',
+				'hero_intro'                  => '   ',
+				'view_place_in_google_maps_aria' => '<strong>View {place}</strong>',
+			]
+		);
+
+		self::assertSame( 'Plan Your Day', $sanitized['hero_title'] );
+		self::assertSame( '', $sanitized['hero_intro'] );
+		self::assertSame( 'View {place}', $sanitized['view_place_in_google_maps_aria'] );
+	}
+
+	public function test_resolve_values_returns_defaults_for_missing_keys(): void {
+		$resolved = InterfaceCopy::resolve_values(
+			[
+				'hero_intro' => '',
+			]
+		);
+
+		self::assertSame( 'Plan Your Day', $resolved['hero_title'] );
+		self::assertSame( '', $resolved['hero_intro'] );
+		self::assertSame( 'Add to trip', $resolved['add_to_trip'] );
+	}
+
+	public function test_format_replaces_named_tokens(): void {
+		self::assertSame(
+			'Results for Coffee',
+			InterfaceCopy::format( 'Results for {search}', [ 'search' => 'Coffee' ] )
+		);
+	}
+}

--- a/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
+++ b/plugin/plan-your-day/tests/PlannerStateBuilderTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Acodebeard\PlanYourDay\Tests;
 
+use Acodebeard\PlanYourDay\Frontend\InterfaceCopy;
 use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
 use Acodebeard\PlanYourDay\Google\GoogleApiResult;
 use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
@@ -205,6 +206,112 @@ final class PlannerStateBuilderTest extends TestCase {
 		self::assertSame( [ 'place-a' ], $state['selected_waypoint_ids'] );
 	}
 
+	public function test_build_uses_custom_interface_copy_for_trip_labels_and_warnings(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'default_location_label'   => 'Downtown',
+					'default_location_address' => '123 Main St',
+					'map_preview_enabled'      => false,
+					'maps_handoff_enabled'     => false,
+					'google_api_timeout'       => 15,
+					'interface_copy'           => array_merge(
+						InterfaceCopy::defaults(),
+						[
+							'trip_timeout_warning' => 'Custom timeout warning.',
+							'trip_count_plural'    => '{count} saved stops',
+						]
+					),
+				]
+			)
+		);
+
+		$google_api_client = new FakePlannerGoogleApiClient(
+			[
+				'place-a' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-a', 'Alpha' ),
+					]
+				),
+				'place-b' => GoogleApiResult::success(
+					[
+						'place' => $this->place( 'place-b', 'Beta' ),
+					]
+				),
+			]
+		);
+		$builder           = $this->planner_state_builder( $google_api_client );
+
+		$warning_state = $builder->build(
+			[
+				'selected_waypoint_ids' => [ 'place-a', 'place-b' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'        => false,
+				'include_trip_waypoints' => true,
+				'trip_waypoint_deadline_at' => microtime( true ) - 1,
+			]
+		);
+		$count_state   = $builder->build(
+			[
+				'selected_waypoint_ids' => [ 'place-a', 'place-b' ],
+				'start_mode'            => Settings::START_MODE_DEFAULT,
+			],
+			[
+				'include_results'        => false,
+				'include_trip_waypoints' => true,
+			]
+		);
+
+		self::assertSame( 'Custom timeout warning.', $warning_state['messages'][0]['text'] ?? '' );
+		self::assertSame( '2 saved stops', $count_state['trip_count_label'] );
+	}
+
+	public function test_build_uses_saved_category_label_and_query_for_category_searches(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'default_location_label'   => 'Downtown',
+					'default_location_address' => '123 Main St',
+					'map_preview_enabled'      => false,
+					'maps_handoff_enabled'     => false,
+					'categories'               => Settings::sanitize_categories(
+						[
+							[
+								'label'       => 'Tea',
+								'description' => 'Tea houses and lounges',
+								'text_query'  => 'tea houses',
+								'slug'        => 'tea',
+								'enabled'     => true,
+								'sort_order'  => 10,
+							],
+						]
+					),
+				]
+			)
+		);
+
+		$google_api_client = new FakePlannerGoogleApiClient( [] );
+		$builder           = $this->planner_state_builder( $google_api_client );
+		$state             = $builder->build(
+			[
+				'category_key' => 'tea',
+				'start_mode'   => Settings::START_MODE_DEFAULT,
+			]
+		);
+
+		self::assertSame( 'Tea', $state['active_search_label'] );
+		self::assertSame( 'tea houses near 123 Main St', $state['search_query'] );
+		self::assertSame( 'tea', $state['category_key'] );
+		self::assertSame( 'Tea', $state['category_catalog']['tea']['label'] ?? null );
+		self::assertSame( 'tea houses near 123 Main St', $google_api_client->last_text_search_query );
+	}
+
 	private function planner_state_builder( GoogleApiClientInterface $google_api_client ): PlannerStateBuilder {
 		$settings = new Settings();
 
@@ -243,6 +350,8 @@ final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
 
 	public int $geocode_calls = 0;
 
+	public string $last_text_search_query = '';
+
 	/**
 	 * @param array<string, GoogleApiResult> $place_details_results
 	 */
@@ -252,6 +361,7 @@ final class FakePlannerGoogleApiClient implements GoogleApiClientInterface {
 
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null ): GoogleApiResult {
 		++$this->text_search_calls;
+		$this->last_text_search_query = $query;
 
 		return GoogleApiResult::success(
 			[

--- a/plugin/plan-your-day/tests/SettingsPageTest.php
+++ b/plugin/plan-your-day/tests/SettingsPageTest.php
@@ -1,0 +1,170 @@
+<?php
+declare( strict_types=1 );
+
+namespace {
+	if ( ! function_exists( 'esc_html' ) ) {
+		function esc_html( string $text ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_html__' ) ) {
+		function esc_html__( string $text, ?string $domain = null ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_html_e' ) ) {
+		function esc_html_e( string $text, ?string $domain = null ): void {
+			echo $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_attr' ) ) {
+		function esc_attr( string $text ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_textarea' ) ) {
+		function esc_textarea( string $text ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_style' ) ) {
+		function wp_enqueue_style( string $handle, string $src = '', array $deps = [], string|bool|null $ver = false, string $media = 'all' ): void {
+			$GLOBALS['plan_your_day_test_enqueued_styles'][ $handle ] = [
+				'src'   => $src,
+				'deps'  => $deps,
+				'ver'   => $ver,
+				'media' => $media,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_script' ) ) {
+		function wp_enqueue_script( string $handle, string $src = '', array $deps = [], string|bool|null $ver = false, array|bool $args = [] ): void {
+			$GLOBALS['plan_your_day_test_enqueued_scripts'][ $handle ] = [
+				'src'  => $src,
+				'deps' => $deps,
+				'ver'  => $ver,
+				'args' => $args,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'checked' ) ) {
+		function checked( mixed $checked, mixed $current = true, bool $display = true ): string {
+			$output = $checked === $current ? 'checked="checked"' : '';
+
+			if ( $display ) {
+				echo $output;
+			}
+
+			return $output;
+		}
+	}
+
+	if ( ! function_exists( 'wp_kses_post' ) ) {
+		function wp_kses_post( string $text ): string {
+			return $text;
+		}
+	}
+}
+
+namespace Acodebeard\PlanYourDay\Tests {
+
+	use Acodebeard\PlanYourDay\Admin\SettingsPage;
+	use Acodebeard\PlanYourDay\Google\GoogleApiCache;
+	use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+	use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+	use Acodebeard\PlanYourDay\Settings\Settings;
+	use PHPUnit\Framework\TestCase;
+
+	final class SettingsPageTest extends TestCase {
+		protected function setUp(): void {
+			$GLOBALS['plan_your_day_test_options']           = [];
+			$GLOBALS['plan_your_day_test_actions']           = [];
+			$GLOBALS['plan_your_day_test_option_reads']      = [];
+			$GLOBALS['plan_your_day_test_enqueued_styles']   = [];
+			$GLOBALS['plan_your_day_test_enqueued_scripts']  = [];
+			$_GET                                            = [];
+
+			if ( ! defined( 'PLAN_YOUR_DAY_VERSION' ) ) {
+				define( 'PLAN_YOUR_DAY_VERSION', 'test-version' );
+			}
+
+			if ( ! defined( 'PLAN_YOUR_DAY_PLUGIN_URL' ) ) {
+				define( 'PLAN_YOUR_DAY_PLUGIN_URL', 'https://example.test/wp-content/plugins/plan-your-day/' );
+			}
+		}
+
+		public function test_render_interface_copy_section_outputs_accordion_with_first_group_open(): void {
+			$settings_page = $this->settings_page();
+
+			ob_start();
+			$settings_page->render_interface_copy_section();
+			$output = (string) ob_get_clean();
+
+			self::assertStringContainsString( 'plan-your-day-admin-accordion', $output );
+			self::assertSame( 1, substr_count( $output, '<details class="plan-your-day-admin-accordion__item" open>' ) );
+			self::assertStringContainsString( 'Top Section And Setup Notice', $output );
+			self::assertStringContainsString( 'Setup notice heading', $output );
+			self::assertStringContainsString( 'Distance Labels', $output );
+		}
+
+		public function test_enqueue_assets_only_runs_on_the_settings_screen(): void {
+			$settings_page = $this->settings_page();
+
+			$settings_page->enqueue_assets( 'dashboard_page_test' );
+
+			self::assertSame( [], $GLOBALS['plan_your_day_test_enqueued_styles'] );
+			self::assertSame( [], $GLOBALS['plan_your_day_test_enqueued_scripts'] );
+
+			$_GET['page'] = Settings::PAGE_SLUG;
+			$settings_page->enqueue_assets( 'settings_page_' . Settings::PAGE_SLUG );
+
+			self::assertArrayHasKey( 'plan-your-day-admin-settings', $GLOBALS['plan_your_day_test_enqueued_styles'] );
+			self::assertArrayHasKey( 'plan-your-day-admin-settings', $GLOBALS['plan_your_day_test_enqueued_scripts'] );
+			self::assertSame(
+				'https://example.test/wp-content/plugins/plan-your-day/assets/css/admin-settings.css',
+				$GLOBALS['plan_your_day_test_enqueued_styles']['plan-your-day-admin-settings']['src']
+			);
+			self::assertSame(
+				'https://example.test/wp-content/plugins/plan-your-day/assets/js/admin-settings.js',
+				$GLOBALS['plan_your_day_test_enqueued_scripts']['plan-your-day-admin-settings']['src']
+			);
+		}
+
+		public function test_categories_field_renders_starter_rows_when_no_categories_have_been_saved(): void {
+			$settings_page = $this->settings_page();
+
+			ob_start();
+			$settings_page->render_field(
+				[
+					'key'         => 'categories',
+					'type'        => 'categories',
+					'description' => '',
+					'attributes'  => [],
+				]
+			);
+			$output = (string) ob_get_clean();
+
+			self::assertStringContainsString( 'Coffee', $output );
+			self::assertStringContainsString( 'coffee shops and cafes', $output );
+			self::assertStringContainsString( 'View built-in starter categories', $output );
+		}
+
+		private function settings_page(): SettingsPage {
+			$settings = new Settings();
+
+			return new SettingsPage(
+				$settings,
+				new GoogleApiCache(),
+				$this->createMock( GoogleApiClientInterface::class ),
+				new CategoryCatalog( $settings )
+			);
+		}
+	}
+}

--- a/plugin/plan-your-day/tests/SettingsTest.php
+++ b/plugin/plan-your-day/tests/SettingsTest.php
@@ -107,6 +107,68 @@ final class SettingsTest extends TestCase {
 		self::assertSame( 'places-key', $settings->get_google_geocoding_api_key() );
 	}
 
+	public function test_get_categories_returns_starter_rows_when_saved_list_is_empty_and_fallback_is_enabled(): void {
+		update_option( Settings::OPTION_NAME, Settings::defaults() );
+
+		$settings = new Settings();
+
+		self::assertSame( Settings::default_categories(), $settings->get_categories() );
+	}
+
+	public function test_get_categories_returns_empty_when_saved_list_is_empty_and_fallback_is_disabled(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'use_preset_categories' => false,
+				]
+			)
+		);
+
+		$settings = new Settings();
+
+		self::assertSame( [], $settings->get_categories() );
+	}
+
+	public function test_seed_default_categories_if_needed_materializes_starter_rows_once(): void {
+		update_option( Settings::OPTION_NAME, Settings::defaults() );
+
+		$settings = new Settings();
+
+		self::assertTrue( $settings->seed_default_categories_if_needed() );
+		self::assertSame( Settings::default_categories(), get_option( Settings::OPTION_NAME )['categories'] ?? [] );
+		self::assertFalse( $settings->seed_default_categories_if_needed() );
+	}
+
+	public function test_seed_default_categories_if_needed_skips_when_fallback_is_disabled(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'use_preset_categories' => false,
+				]
+			)
+		);
+
+		$settings = new Settings();
+
+		self::assertFalse( $settings->seed_default_categories_if_needed() );
+		self::assertSame( [], get_option( Settings::OPTION_NAME )['categories'] ?? [] );
+	}
+
+	public function test_maybe_upgrade_seeds_default_categories_and_updates_schema_version_for_existing_empty_installs(): void {
+		update_option( Settings::OPTION_NAME, Settings::defaults() );
+		update_option( 'plan_your_day_schema_version', 1 );
+
+		$settings = new Settings();
+		$settings->maybe_upgrade();
+
+		self::assertSame( Settings::default_categories(), get_option( Settings::OPTION_NAME )['categories'] ?? [] );
+		self::assertSame( 2, get_option( 'plan_your_day_schema_version' ) );
+	}
+
 	public function test_sanitize_trusted_proxy_cidrs_accepts_ipv4_and_ipv6_edge_masks(): void {
 		$sanitized = Settings::sanitize_trusted_proxy_cidrs(
 			" 0.0.0.0/0,\n192.0.2.10/32\n2001:DB8::/32\n::/0\n2001:db8::1/128\nfe80::/10 "
@@ -172,5 +234,35 @@ final class SettingsTest extends TestCase {
 
 		self::assertSame( 'After', $settings->get_default_location_label() );
 		self::assertSame( 2, $GLOBALS['plan_your_day_test_option_reads'][ Settings::OPTION_NAME ] ?? 0 );
+	}
+
+	public function test_frontend_copy_getters_apply_saved_values_and_named_tokens(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array_merge(
+				Settings::defaults(),
+				[
+					'interface_copy' => array_merge(
+						Settings::defaults()['interface_copy'],
+						[
+							'hero_title'             => 'Build Your Route',
+							'setup_notice_body'      => 'Missing: {settings}.',
+							'category_card_help'     => '',
+							'update_results_button'  => '',
+						]
+					),
+				]
+			)
+		);
+
+		$settings = new Settings();
+
+		self::assertSame( 'Build Your Route', $settings->get_frontend_copy_value( 'hero_title' ) );
+		self::assertSame( '', $settings->get_frontend_copy_value( 'category_card_help' ) );
+		self::assertSame( 'Update results', $settings->get_frontend_copy_value( 'update_results_button' ) );
+		self::assertSame(
+			'Missing: Default location label.',
+			$settings->format_frontend_copy( 'setup_notice_body', [ 'settings' => 'Default location label' ] )
+		);
 	}
 }


### PR DESCRIPTION
## Summary
This PR moves the frontend category buttons onto the editable settings path and adds the recent admin interface-copy/settings UX work.

## What changed
- adds editable frontend interface copy definitions and settings support
- converts the long interface-copy admin screen into an accordion and adds a back-to-top control
- treats the built-in category set as starter rows managed through the editable category settings flow
- seeds starter categories for fresh installs and upgrades older installs that were still using the empty-list-plus-fallback model
- keeps category sanitization, ordering, enabled state, removal, and query editing in the existing category settings architecture
- updates category-related frontend copy and developer documentation to reflect the new editable-category behavior
- adds and updates tests covering activation, settings resolution, category catalogs, settings-page rendering, and category-driven planner searches

## Why
The plugin still had a split between hardcoded visible categories and admin-managed custom categories. That made the frontend defaults feel permanent and forced category customization into an override path instead of the primary settings path. This change makes the category list shown on the frontend editable through the same system that stores and validates category settings.

## Impact
- existing installs keep the same visible category set unless an admin changes it
- fresh installs start with a saved editable category list instead of a separate permanent hardcoded list
- admins can add, edit, disable, remove, and reorder categories without losing generic plugin behavior

## Validation
- `./tools/php-runner.sh tools/lint.php`
- `./tools/php-runner.sh vendor/bin/phpunit --configuration phpunit.xml.dist`
- `./tools/php-runner.sh vendor/bin/phpcs -n --standard=phpcs.xml.dist`