### PR TITLE
Fix category template rows in settings

### DIFF
--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -1132,7 +1132,7 @@ final class SettingsPage {
 						'sort_order'  => $next_sort,
 					]
 				);
-					echo wp_kses_post( trim( (string) ob_get_clean() ) );
+				echo trim( (string) ob_get_clean() );
 				?>
 			</template>
 		</div>

--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -1132,7 +1132,9 @@ final class SettingsPage {
 						'sort_order'  => $next_sort,
 					]
 				);
-				echo trim( (string) ob_get_clean() );
+				$template_row_markup = trim( (string) ob_get_clean() );
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Markup is assembled by render_category_editor_row() from escaped field values.
+				echo $template_row_markup;
 				?>
 			</template>
 		</div>

--- a/plugin/plan-your-day/tests/SettingsPageTest.php
+++ b/plugin/plan-your-day/tests/SettingsPageTest.php
@@ -156,6 +156,26 @@ namespace Acodebeard\PlanYourDay\Tests {
 			self::assertStringContainsString( 'View built-in starter categories', $output );
 		}
 
+		public function test_categories_field_template_keeps_new_row_form_controls(): void {
+			$settings_page = $this->settings_page();
+
+			ob_start();
+			$settings_page->render_field(
+				[
+					'key'         => 'categories',
+					'type'        => 'categories',
+					'description' => '',
+					'attributes'  => [],
+				]
+			);
+			$output = (string) ob_get_clean();
+
+			self::assertStringContainsString( '<template data-plan-category-row-template>', $output );
+			self::assertStringContainsString( 'plan_your_day_settings[categories][__INDEX__][label]', $output );
+			self::assertStringContainsString( 'plan_your_day_settings[categories][__INDEX__][description]', $output );
+			self::assertStringContainsString( 'plan_your_day_settings[categories][__INDEX__][text_query]', $output );
+		}
+
 		private function settings_page(): SettingsPage {
 			$settings = new Settings();
 


### PR DESCRIPTION
Closes #84

## Summary of the fix
Stopped sanitizing the plugin-generated category row template with `wp_kses_post()` before outputting it inside the `<template>` element, so `Add category` now inserts usable form controls.

## Files changed
- `plugin/plan-your-day/src/Admin/SettingsPage.php`
- `plugin/plan-your-day/tests/SettingsPageTest.php`

## Testing performed
- `php -l plugin/plan-your-day/src/Admin/SettingsPage.php`
- `php -l plugin/plan-your-day/tests/SettingsPageTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml.dist --filter SettingsPageTest`

## Remaining manual testing needed
- Open `Settings > Plan Your Day` in a WordPress admin screen and verify that clicking `Add category` inserts a row with editable controls.

## Priority
`priority: high`

## Scope check
No unrelated files or behavior changes are included in this PR.