### PR TITLE
Skip route rebuild on load more

### DIFF
--- a/plugin/plan-your-day/src/Rest/PlannerRoutes.php
+++ b/plugin/plan-your-day/src/Rest/PlannerRoutes.php
@@ -246,9 +246,14 @@ final class PlannerRoutes {
 	private function get_rate_limit_cost( string $scope, array $request_state ): int {
 		$cost               = self::RATE_LIMIT_BASE_COST;
 		$selected_waypoints = array_values( (array) ( $request_state['selected_waypoint_ids'] ?? [] ) );
+		$append_results     = ! empty( $request_state['append_results'] );
 
 		if ( 'browse' === $scope && $this->request_uses_google_search( $request_state ) ) {
 			$cost += self::BROWSE_SEARCH_COST;
+		}
+
+		if ( 'browse' === $scope && $append_results ) {
+			return $cost;
 		}
 
 		return $cost + count( $selected_waypoints );

--- a/plugin/plan-your-day/src/Rest/PlannerRoutes.php
+++ b/plugin/plan-your-day/src/Rest/PlannerRoutes.php
@@ -90,9 +90,16 @@ final class PlannerRoutes {
 			return $guard;
 		}
 
+		$append_results_request = ! empty( $request_state['append_results'] );
+		$build_options          = $this->public_trip_waypoint_options( true );
+
+		if ( $append_results_request ) {
+			$build_options['include_trip_waypoints'] = false;
+		}
+
 		$planner_state = $this->planner_state_builder->build(
 			$request_state,
-			$this->public_trip_waypoint_options( true )
+			$build_options
 		);
 		DebugLogger::log(
 			'rest.browse.response',
@@ -108,12 +115,15 @@ final class PlannerRoutes {
 			]
 		);
 
-		return new WP_REST_Response(
-			[
-				'browse' => $this->planner_payload_builder->build_browse_payload( $planner_state ),
-				'route'  => $this->planner_payload_builder->build_route_payload( $planner_state ),
-			]
-		);
+		$response_payload = [
+			'browse' => $this->planner_payload_builder->build_browse_payload( $planner_state ),
+		];
+
+		if ( ! $append_results_request ) {
+			$response_payload['route'] = $this->planner_payload_builder->build_route_payload( $planner_state );
+		}
+
+		return new WP_REST_Response( $response_payload );
 	}
 
 	public function route( WP_REST_Request $request ): WP_REST_Response|WP_Error {

--- a/plugin/plan-your-day/tests/PlannerRoutesTest.php
+++ b/plugin/plan-your-day/tests/PlannerRoutesTest.php
@@ -167,7 +167,7 @@ final class PlannerRoutesTest extends TestCase {
 		self::assertSame( 'plan_your_day_rate_limited', $second->get_error_code() );
 	}
 
-	public function test_browse_returns_pagination_metadata_and_preserves_selected_waypoints_in_append_mode(): void {
+	public function test_browse_append_results_skips_route_payload_and_trip_waypoint_resolution(): void {
 		$google_api_client = new PlannerRoutesGoogleApiClient(
 			GoogleApiResult::success(
 				[
@@ -222,8 +222,9 @@ final class PlannerRoutesTest extends TestCase {
 		self::assertSame( 'page-3', $data['browse']['nextPageToken'] ?? '' );
 		self::assertTrue( $data['browse']['hasMoreResults'] ?? false );
 		self::assertNotSame( '', $data['browse']['searchContextKey'] ?? '' );
-		self::assertSame( [ 'trip-1' ], $data['route']['selectedWaypointIds'] ?? [] );
+		self::assertArrayNotHasKey( 'route', $data );
 		self::assertSame( 'page-2', $google_api_client->last_page_token );
+		self::assertSame( [], $google_api_client->requested_place_ids );
 	}
 
 	private function build_routes( int $rate_limit_per_minute, array $settings_overrides = [], ?GoogleApiClientInterface $google_api_client = null ): PlannerRoutes {
@@ -289,6 +290,9 @@ final class PlannerRoutesGoogleApiClient implements GoogleApiClientInterface {
 
 	public string $last_page_token = '';
 
+	/** @var array<int, string> */
+	public array $requested_place_ids = [];
+
 	/**
 	 * @param array<string, GoogleApiResult> $place_details_results
 	 */
@@ -304,6 +308,8 @@ final class PlannerRoutesGoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	public function place_details( string $place_id, ?int $timeout = null ): GoogleApiResult {
+		$this->requested_place_ids[] = $place_id;
+
 		return $this->place_details_results[ $place_id ] ?? GoogleApiResult::success( [ 'place' => [] ] );
 	}
 

--- a/plugin/plan-your-day/tests/PlannerRoutesTest.php
+++ b/plugin/plan-your-day/tests/PlannerRoutesTest.php
@@ -100,6 +100,19 @@ final class PlannerRoutesTest extends TestCase {
 			3,
 			$method->invoke(
 				$routes,
+				'browse',
+				[
+					'category_key'          => 'coffee',
+					'category_search'       => '',
+					'selected_waypoint_ids' => [ 'place-1', 'place-2' ],
+					'append_results'        => true,
+				]
+			)
+		);
+		self::assertSame(
+			3,
+			$method->invoke(
+				$routes,
 				'route',
 				[
 					'category_key'          => 'coffee',


### PR DESCRIPTION
Closes #104

## Summary of the fix
- detect append-results browse requests before building planner state
- skip trip waypoint resolution for that load-more path
- omit the route payload from append-results responses so the client keeps its existing route state
- add a regression test covering the missing route payload and skipped place-details calls

## Files changed
- `plugin/plan-your-day/src/Rest/PlannerRoutes.php`
- `plugin/plan-your-day/tests/PlannerRoutesTest.php`

## Testing performed
- `php -l plugin/plan-your-day/src/Rest/PlannerRoutes.php`
- `php -l plugin/plan-your-day/tests/PlannerRoutesTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml.dist --filter PlannerRoutesTest`

## Remaining manual testing needed
- verify load-more keeps the existing trip preview and Google Maps handoff intact in the browser
- verify append-results requests no longer trigger trip waypoint detail lookups in debug traces

## Priority label
- `priority: medium`

No unrelated changes.