### PR TITLE
Serialize rate limiter lock acquisition

### DIFF
--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -124,6 +124,23 @@ final class RateLimiter {
 	}
 
 	private function acquire_lock( string $key, float $now ): bool {
+		if ( $this->uses_external_object_cache() ) {
+			return wp_cache_add(
+				$this->lock_option_name( $key ),
+				$now + self::LOCK_TIMEOUT_SECONDS,
+				self::CACHE_GROUP,
+				(int) ceil( self::LOCK_TIMEOUT_SECONDS )
+			);
+		}
+
+		if ( $this->can_use_database_advisory_locks() ) {
+			return $this->acquire_database_advisory_lock( $key );
+		}
+
+		return $this->acquire_option_lock_fallback( $key, $now );
+	}
+
+	private function acquire_option_lock_fallback( string $key, float $now ): bool {
 		$option_name = $this->lock_option_name( $key );
 
 		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
@@ -147,13 +164,66 @@ final class RateLimiter {
 		return false;
 	}
 
+	private function acquire_database_advisory_lock( string $key ): bool {
+		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
+			$result = $this->database_lock_result(
+				'SELECT GET_LOCK(%s, %d)',
+				$this->database_lock_name( $key ),
+				0
+			);
+
+			if ( is_scalar( $result ) && '1' === (string) $result ) {
+				return true;
+			}
+
+			if ( $attempt < self::LOCK_RETRY_ATTEMPTS - 1 ) {
+				usleep( self::LOCK_RETRY_DELAY_MICROSECONDS );
+			}
+		}
+
+		return false;
+	}
+
 	private function release_lock( string $key ): void {
+		if ( $this->uses_external_object_cache() ) {
+			wp_cache_delete( $this->lock_option_name( $key ), self::CACHE_GROUP );
+			return;
+		}
+
+		if ( $this->can_use_database_advisory_locks() ) {
+			$this->database_lock_result(
+				'SELECT RELEASE_LOCK(%s)',
+				$this->database_lock_name( $key )
+			);
+			return;
+		}
+
 		delete_option( $this->lock_option_name( $key ) );
+	}
+
+	private function database_lock_name( string $key ): string {
+		return substr( self::LOCK_OPTION_PREFIX . $key, 0, 64 );
+	}
+
+	private function can_use_database_advisory_locks(): bool {
+		global $wpdb;
+
+		return isset( $wpdb )
+			&& is_object( $wpdb )
+			&& method_exists( $wpdb, 'prepare' )
+			&& method_exists( $wpdb, 'get_var' );
+	}
+
+	private function database_lock_result( string $query, mixed ...$args ): mixed {
+		global $wpdb;
+
+		return $wpdb->get_var( $wpdb->prepare( $query, ...$args ) );
 	}
 
 	private function uses_external_object_cache(): bool {
 		return function_exists( 'wp_using_ext_object_cache' )
 			&& function_exists( 'wp_cache_get' )
+			&& function_exists( 'wp_cache_add' )
 			&& function_exists( 'wp_cache_set' )
 			&& function_exists( 'wp_cache_delete' )
 			&& wp_using_ext_object_cache();

--- a/plugin/plan-your-day/src/Security/RateLimiter.php
+++ b/plugin/plan-your-day/src/Security/RateLimiter.php
@@ -9,12 +9,12 @@ use WP_Error;
 defined( 'ABSPATH' ) || exit;
 
 final class RateLimiter {
-	private const WINDOW_SECONDS = 60;
-	private const CACHE_GROUP = 'plan-your-day';
-	private const STATE_OPTION_PREFIX = 'plan_your_day_rate_';
-	private const LOCK_OPTION_PREFIX = 'plan_your_day_rate_lock_';
-	private const LOCK_TIMEOUT_SECONDS = 5.0;
-	private const LOCK_RETRY_ATTEMPTS = 5;
+	private const WINDOW_SECONDS                = 60;
+	private const CACHE_GROUP                   = 'plan-your-day';
+	private const STATE_OPTION_PREFIX           = 'plan_your_day_rate_';
+	private const LOCK_OPTION_PREFIX            = 'plan_your_day_rate_lock_';
+	private const LOCK_TIMEOUT_SECONDS          = 5.0;
+	private const LOCK_RETRY_ATTEMPTS           = 5;
 	private const LOCK_RETRY_DELAY_MICROSECONDS = 20000;
 
 	private Settings $settings;
@@ -166,11 +166,7 @@ final class RateLimiter {
 
 	private function acquire_database_advisory_lock( string $key ): bool {
 		for ( $attempt = 0; $attempt < self::LOCK_RETRY_ATTEMPTS; $attempt++ ) {
-			$result = $this->database_lock_result(
-				'SELECT GET_LOCK(%s, %d)',
-				$this->database_lock_name( $key ),
-				0
-			);
+			$result = $this->get_database_advisory_lock_result( $key );
 
 			if ( is_scalar( $result ) && '1' === (string) $result ) {
 				return true;
@@ -191,10 +187,7 @@ final class RateLimiter {
 		}
 
 		if ( $this->can_use_database_advisory_locks() ) {
-			$this->database_lock_result(
-				'SELECT RELEASE_LOCK(%s)',
-				$this->database_lock_name( $key )
-			);
+			$this->release_database_advisory_lock( $key );
 			return;
 		}
 
@@ -214,10 +207,27 @@ final class RateLimiter {
 			&& method_exists( $wpdb, 'get_var' );
 	}
 
-	private function database_lock_result( string $query, mixed ...$args ): mixed {
+	private function get_database_advisory_lock_result( string $key ): mixed {
 		global $wpdb;
 
-		return $wpdb->get_var( $wpdb->prepare( $query, ...$args ) );
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT GET_LOCK(%s, %d)',
+				$this->database_lock_name( $key ),
+				0
+			)
+		);
+	}
+
+	private function release_database_advisory_lock( string $key ): void {
+		global $wpdb;
+
+		$wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT RELEASE_LOCK(%s)',
+				$this->database_lock_name( $key )
+			)
+		);
 	}
 
 	private function uses_external_object_cache(): bool {

--- a/plugin/plan-your-day/tests/RateLimiterTest.php
+++ b/plugin/plan-your-day/tests/RateLimiterTest.php
@@ -11,9 +11,18 @@ use WP_Error;
 
 final class RateLimiterTest extends TestCase {
 	protected function setUp(): void {
-		$GLOBALS['plan_your_day_test_options']      = [];
-		$GLOBALS['plan_your_day_test_object_cache'] = [];
+		parent::setUp();
+
+		$GLOBALS['plan_your_day_test_options']         = [];
+		$GLOBALS['plan_your_day_test_object_cache']    = [];
 		$GLOBALS['plan_your_day_use_ext_object_cache'] = false;
+		$this->install_database_lock_driver();
+	}
+
+	protected function tearDown(): void {
+		unset( $GLOBALS['wpdb'] );
+
+		parent::tearDown();
 	}
 
 	public function test_enforce_allows_requests_until_the_limit_then_blocks(): void {
@@ -58,23 +67,39 @@ final class RateLimiterTest extends TestCase {
 		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
 	}
 
-	public function test_enforce_recovers_from_a_stale_lock(): void {
-		$now = 200.0;
-		update_option(
-			'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
-			150.0
-		);
+	public function test_enforce_uses_database_advisory_locks_without_writing_lock_options(): void {
+		$now     = 200.0;
 		$limiter = $this->build_limiter( 2, $now );
+		$key     = hash( 'sha256', 'browse|198.51.100.10' );
 
 		$result = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
 
 		self::assertNull( $result );
+		self::assertSame( 1, $GLOBALS['wpdb']->get_lock_calls );
+		self::assertSame( 1, $GLOBALS['wpdb']->release_lock_calls );
+		self::assertSame(
+			'plan_your_day_rate_lock_' . substr( $key, 0, 40 ),
+			$GLOBALS['wpdb']->queries[0]['args'][0] ?? null
+		);
 		self::assertFalse(
 			array_key_exists(
-				'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
+				'plan_your_day_rate_lock_' . $key,
 				$GLOBALS['plan_your_day_test_options']
 			)
 		);
+	}
+
+	public function test_enforce_returns_rate_limited_error_when_database_lock_cannot_be_acquired(): void {
+		$GLOBALS['wpdb'] = $this->install_database_lock_driver( [ 0, 0, 0, 0, 0 ] );
+
+		$now     = 1000.0;
+		$limiter = $this->build_limiter( 2, $now );
+		$error   = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
+		self::assertSame( 5, $GLOBALS['wpdb']->get_lock_calls );
+		self::assertSame( 0, $GLOBALS['wpdb']->release_lock_calls );
 	}
 
 	public function test_enforce_uses_external_object_cache_without_writing_rate_state_options(): void {
@@ -107,23 +132,32 @@ final class RateLimiterTest extends TestCase {
 		);
 	}
 
-	public function test_enforce_recovers_from_a_stale_external_object_cache_lock(): void {
+	public function test_enforce_rejects_when_external_object_cache_lock_is_already_held(): void {
 		$GLOBALS['plan_your_day_use_ext_object_cache'] = true;
+
+		$now = 200.0;
+		$key = hash( 'sha256', 'browse|198.51.100.10' );
+		$GLOBALS['plan_your_day_test_object_cache']['plan-your-day'][ 'plan_your_day_rate_lock_' . $key ] = $now + 5.0;
+
+		$limiter = $this->build_limiter( 2, $now );
+		$error   = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
+
+		self::assertInstanceOf( WP_Error::class, $error );
+		self::assertSame( 'plan_your_day_rate_limited', $error->get_error_code() );
+	}
+
+	public function test_enforce_falls_back_to_option_lock_when_database_advisory_locks_are_unavailable(): void {
+		unset( $GLOBALS['wpdb'] );
 
 		$now = 200.0;
 		update_option(
 			'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
 			150.0
 		);
-
 		$limiter = $this->build_limiter( 2, $now );
 		$result  = $limiter->enforce( 'browse', [ 'REMOTE_ADDR' => '198.51.100.10' ] );
 
 		self::assertNull( $result );
-		self::assertArrayHasKey(
-			'plan_your_day_rate_' . hash( 'sha256', 'browse|198.51.100.10' ),
-			$GLOBALS['plan_your_day_test_object_cache']['plan-your-day']
-		);
 		self::assertFalse(
 			array_key_exists(
 				'plan_your_day_rate_lock_' . hash( 'sha256', 'browse|198.51.100.10' ),
@@ -150,5 +184,57 @@ final class RateLimiterTest extends TestCase {
 				return $now;
 			}
 		);
+	}
+
+	private function install_database_lock_driver( array $get_lock_results = [], array $release_lock_results = [] ): object {
+		$GLOBALS['wpdb'] = new class( $get_lock_results, $release_lock_results ) {
+			public array $queries = [];
+			public int $get_lock_calls = 0;
+			public int $release_lock_calls = 0;
+
+			private array $get_lock_results;
+			private array $release_lock_results;
+
+			public function __construct( array $get_lock_results, array $release_lock_results ) {
+				$this->get_lock_results     = $get_lock_results;
+				$this->release_lock_results = $release_lock_results;
+			}
+
+			public function prepare( string $query, mixed ...$args ): string {
+				return (string) json_encode(
+					[
+						'query' => $query,
+						'args'  => $args,
+					]
+				);
+			}
+
+			public function get_var( string $prepared_query ): mixed {
+				$payload = json_decode( $prepared_query, true );
+				$query   = is_array( $payload ) ? (string) ( $payload['query'] ?? '' ) : $prepared_query;
+				$args    = is_array( $payload ) ? (array) ( $payload['args'] ?? [] ) : [];
+
+				$this->queries[] = [
+					'query' => $query,
+					'args'  => $args,
+				];
+
+				if ( str_contains( $query, 'GET_LOCK' ) ) {
+					++$this->get_lock_calls;
+
+					return array_shift( $this->get_lock_results ) ?? 1;
+				}
+
+				if ( str_contains( $query, 'RELEASE_LOCK' ) ) {
+					++$this->release_lock_calls;
+
+					return array_shift( $this->release_lock_results ) ?? 1;
+				}
+
+				return null;
+			}
+		};
+
+		return $GLOBALS['wpdb'];
 	}
 }


### PR DESCRIPTION
Follow-up to review feedback on #93.

## Scope
This PR only changes rate-limiter lock acquisition.
It does not change request origin validation, endpoint token validation, or other REST guard behavior.

## Summary of the fix
- use `wp_cache_add()` / `wp_cache_delete()` for atomic lock handling when an external object cache is active
- use database advisory locks via `$wpdb` (`GET_LOCK` / `RELEASE_LOCK`) for the normal database-backed path
- keep the existing option-row lock only as a last-resort fallback when advisory-lock support is unavailable
- update the rate-limiter tests to cover advisory locks, object-cache locks, and the fallback path

## Files changed
- `plugin/plan-your-day/src/Security/RateLimiter.php`
- `plugin/plan-your-day/tests/RateLimiterTest.php`

## Testing performed
- `php -l plugin/plan-your-day/src/Security/RateLimiter.php`
- `php -l plugin/plan-your-day/tests/RateLimiterTest.php`
- `plugin/plan-your-day/vendor/bin/phpunit --configuration plugin/plan-your-day/phpunit.xml.dist --filter RateLimiterTest`
- `plugin/plan-your-day/vendor/bin/phpunit --configuration plugin/plan-your-day/phpunit.xml.dist --filter PlannerRoutesTest`
- `plugin/plan-your-day/vendor/bin/phpunit --configuration plugin/plan-your-day/phpunit.xml.dist`

## Scope check
No request-origin validation changes, no frontend copy changes, and no category/settings changes are included in this PR.