### PR TITLE
[codex] Add block wrapper entry point

### DIFF
--- a/plugin/plan-your-day/assets/js/plan-block.js
+++ b/plugin/plan-your-day/assets/js/plan-block.js
@@ -1,0 +1,62 @@
+( function( blocks, blockEditor, components, element, i18n ) {
+	'use strict';
+
+	var el = element.createElement;
+	var Fragment = element.Fragment;
+	var __ = i18n.__;
+	var InspectorControls = blockEditor.InspectorControls;
+	var useBlockProps = blockEditor.useBlockProps;
+	var PanelBody = components.PanelBody;
+	var Placeholder = components.Placeholder;
+	var TextControl = components.TextControl;
+
+	blocks.registerBlockType( 'plan-your-day/planner', {
+		edit: function( props ) {
+			var attributes = props.attributes || {};
+			var blockProps = useBlockProps();
+
+			return el(
+				Fragment,
+				null,
+				el(
+					InspectorControls,
+					null,
+					el(
+						PanelBody,
+						{
+							title: __( 'Planner settings', 'plan-your-day' ),
+							initialOpen: true,
+						},
+						el( TextControl, {
+							label: __( 'Action URL', 'plan-your-day' ),
+							help: __( 'Optional. Submit planner updates to a specific page URL instead of the current page.', 'plan-your-day' ),
+							value: attributes.actionUrl || '',
+							onChange: function( value ) {
+								props.setAttributes( { actionUrl: value } );
+							},
+						} )
+					)
+				),
+				el(
+					'div',
+					blockProps,
+					el(
+						Placeholder,
+						{
+							label: __( 'Plan Your Day', 'plan-your-day' ),
+							instructions: __( 'The frontend uses the same planner renderer as the shortcode. Configure an optional action URL in the block settings.', 'plan-your-day' ),
+						},
+						el(
+							'p',
+							null,
+							__( 'Planner styles and interactions load only when this block is rendered on the page.', 'plan-your-day' )
+						)
+					)
+				)
+			);
+		},
+		save: function() {
+			return null;
+		},
+	} );
+} )( window.wp.blocks, window.wp.blockEditor, window.wp.components, window.wp.element, window.wp.i18n );

--- a/plugin/plan-your-day/blocks/planner/block.json
+++ b/plugin/plan-your-day/blocks/planner/block.json
@@ -1,0 +1,25 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "plan-your-day/planner",
+	"title": "Plan Your Day",
+	"category": "widgets",
+	"icon": "location-alt",
+	"description": "Render the Plan Your Day planner through the block editor.",
+	"textdomain": "plan-your-day",
+	"keywords": [
+		"planner",
+		"maps",
+		"waypoints"
+	],
+	"attributes": {
+		"actionUrl": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false
+	},
+	"editorScript": "plan-your-day-block-editor"
+}

--- a/plugin/plan-your-day/src/Frontend/FrontendAssets.php
+++ b/plugin/plan-your-day/src/Frontend/FrontendAssets.php
@@ -8,6 +8,7 @@ defined( 'ABSPATH' ) || exit;
 final class FrontendAssets {
 	public const STYLE_HANDLE = 'plan-your-day';
 	public const SCRIPT_HANDLE = 'plan-your-day';
+	public const BLOCK_EDITOR_SCRIPT_HANDLE = 'plan-your-day-block-editor';
 
 	public function register(): void {
 		wp_register_style(
@@ -26,6 +27,20 @@ final class FrontendAssets {
 				'in_footer' => true,
 				'strategy'  => 'defer',
 			]
+		);
+
+		wp_register_script(
+			self::BLOCK_EDITOR_SCRIPT_HANDLE,
+			PLAN_YOUR_DAY_PLUGIN_URL . 'assets/js/plan-block.js',
+			[
+				'wp-block-editor',
+				'wp-blocks',
+				'wp-components',
+				'wp-element',
+				'wp-i18n',
+			],
+			PLAN_YOUR_DAY_VERSION,
+			true
 		);
 	}
 

--- a/plugin/plan-your-day/src/Frontend/PlannerBlock.php
+++ b/plugin/plan-your-day/src/Frontend/PlannerBlock.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types=1 );
+
+namespace Acodebeard\PlanYourDay\Frontend;
+
+defined( 'ABSPATH' ) || exit;
+
+final class PlannerBlock {
+	public const NAME = 'plan-your-day/planner';
+
+	private PlannerRenderer $renderer;
+	private FrontendAssets $assets;
+
+	public function __construct( PlannerRenderer $renderer, FrontendAssets $assets ) {
+		$this->renderer = $renderer;
+		$this->assets   = $assets;
+	}
+
+	public function register(): void {
+		if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
+			return;
+		}
+
+		register_block_type_from_metadata(
+			PLAN_YOUR_DAY_PLUGIN_DIR . 'blocks/planner',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	public function render( array $attributes = [], string $content = '', mixed $block = null ): string {
+		unset( $content, $block );
+
+		$action_url = isset( $attributes['actionUrl'] ) ? esc_url_raw( (string) $attributes['actionUrl'] ) : '';
+
+		$this->assets->enqueue();
+
+		return $this->renderer->render( $_GET, $action_url );
+	}
+}

--- a/plugin/plan-your-day/src/Plugin.php
+++ b/plugin/plan-your-day/src/Plugin.php
@@ -5,6 +5,7 @@ namespace Acodebeard\PlanYourDay;
 
 use Acodebeard\PlanYourDay\Admin\SettingsPage;
 use Acodebeard\PlanYourDay\Frontend\FrontendAssets;
+use Acodebeard\PlanYourDay\Frontend\PlannerBlock;
 use Acodebeard\PlanYourDay\Frontend\PlannerRenderer;
 use Acodebeard\PlanYourDay\Frontend\PlannerShortcode;
 use Acodebeard\PlanYourDay\Google\CachedGoogleApiClient;
@@ -51,6 +52,7 @@ final class Plugin {
 	private FrontendAssets $frontend_assets;
 	private PlannerRenderer $planner_renderer;
 	private PlannerShortcode $planner_shortcode;
+	private PlannerBlock $planner_block;
 	private PlannerRoutes $planner_routes;
 
 	public static function instance(): Plugin {
@@ -91,6 +93,7 @@ final class Plugin {
 			$this->visitor_token_manager
 		);
 		$this->planner_shortcode        = new PlannerShortcode( $this->planner_renderer, $this->frontend_assets );
+		$this->planner_block            = new PlannerBlock( $this->planner_renderer, $this->frontend_assets );
 		$this->planner_routes           = new PlannerRoutes(
 			$this->request_state_parser,
 			$this->planner_state_builder(),
@@ -105,9 +108,10 @@ final class Plugin {
 	public function init(): void {
 		add_action( 'init', [ $this, 'load_textdomain' ], 0 );
 		add_action( 'init', [ $this->settings, 'maybe_upgrade' ], 1 );
+		add_action( 'init', [ $this->frontend_assets, 'register' ], 2 );
 		add_action( 'init', [ $this->planner_shortcode, 'register' ] );
+		add_action( 'init', [ $this->planner_block, 'register' ] );
 		add_action( 'rest_api_init', [ $this->planner_routes, 'register' ] );
-		add_action( 'wp_enqueue_scripts', [ $this->frontend_assets, 'register' ] );
 		add_action( 'admin_init', [ $this->settings, 'register' ] );
 		add_action( 'admin_menu', [ $this->settings_page, 'register' ] );
 		add_action( 'admin_enqueue_scripts', [ $this->settings_page, 'enqueue_assets' ] );

--- a/plugin/plan-your-day/tests/FrontendAssetsTest.php
+++ b/plugin/plan-your-day/tests/FrontendAssetsTest.php
@@ -81,6 +81,20 @@ namespace Acodebeard\PlanYourDay\Tests {
 				'https://example.test/wp-content/plugins/plan-your-day/assets/js/plan.min.js',
 				$GLOBALS['plan_your_day_test_registered_scripts'][ FrontendAssets::SCRIPT_HANDLE ]['src'] ?? null
 			);
+			self::assertSame(
+				'https://example.test/wp-content/plugins/plan-your-day/assets/js/plan-block.js',
+				$GLOBALS['plan_your_day_test_registered_scripts'][ FrontendAssets::BLOCK_EDITOR_SCRIPT_HANDLE ]['src'] ?? null
+			);
+			self::assertSame(
+				[
+					'wp-block-editor',
+					'wp-blocks',
+					'wp-components',
+					'wp-element',
+					'wp-i18n',
+				],
+				$GLOBALS['plan_your_day_test_registered_scripts'][ FrontendAssets::BLOCK_EDITOR_SCRIPT_HANDLE ]['deps'] ?? null
+			);
 		}
 
 		public function test_enqueue_uses_registered_frontend_asset_handles(): void {

--- a/plugin/plan-your-day/tests/PlannerBlockTest.php
+++ b/plugin/plan-your-day/tests/PlannerBlockTest.php
@@ -1,0 +1,208 @@
+<?php
+declare( strict_types=1 );
+
+namespace {
+	if ( ! function_exists( 'register_block_type_from_metadata' ) ) {
+		function register_block_type_from_metadata( string $path, array $args = [] ): array {
+			$GLOBALS['plan_your_day_test_registered_blocks'][] = [
+				'path' => $path,
+				'args' => $args,
+			];
+
+			return [
+				'path' => $path,
+				'args' => $args,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_style' ) ) {
+		function wp_enqueue_style( string $handle, string $src = '', array $deps = [], string|bool|null $ver = false, string $media = 'all' ): void {
+			$GLOBALS['plan_your_day_test_enqueued_styles'][ $handle ] = [
+				'src'   => $src,
+				'deps'  => $deps,
+				'ver'   => $ver,
+				'media' => $media,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'wp_enqueue_script' ) ) {
+		function wp_enqueue_script( string $handle, string $src = '', array $deps = [], string|bool|null $ver = false, array|bool $args = [] ): void {
+			$GLOBALS['plan_your_day_test_enqueued_scripts'][ $handle ] = [
+				'src'  => $src,
+				'deps' => $deps,
+				'ver'  => $ver,
+				'args' => $args,
+			];
+		}
+	}
+
+	if ( ! function_exists( 'esc_html' ) ) {
+		function esc_html( string $text ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_attr' ) ) {
+		function esc_attr( string $text ): string {
+			return $text;
+		}
+	}
+
+	if ( ! function_exists( 'esc_url' ) ) {
+		function esc_url( string $url ): string {
+			return $url;
+		}
+	}
+
+	if ( ! function_exists( 'current_user_can' ) ) {
+		function current_user_can( string $capability ): bool {
+			unset( $capability );
+
+			return false;
+		}
+	}
+
+	if ( ! function_exists( 'admin_url' ) ) {
+		function admin_url( string $path = '' ): string {
+			return 'https://example.test/wp-admin/' . ltrim( $path, '/' );
+		}
+	}
+
+	if ( ! function_exists( 'rest_url' ) ) {
+		function rest_url( string $path = '' ): string {
+			return 'https://example.test/wp-json/' . ltrim( $path, '/' );
+		}
+	}
+
+	if ( ! function_exists( 'disabled' ) ) {
+		function disabled( mixed $disabled, mixed $current = true, bool $display = true ): string {
+			$output = $disabled === $current ? 'disabled="disabled"' : '';
+
+			if ( $display ) {
+				echo $output;
+			}
+
+			return $output;
+		}
+	}
+
+	if ( ! function_exists( 'wp_unique_id' ) ) {
+		function wp_unique_id( string $prefix = '' ): string {
+			$GLOBALS['plan_your_day_test_unique_id'] = (int) ( $GLOBALS['plan_your_day_test_unique_id'] ?? 0 ) + 1;
+
+			return $prefix . (string) $GLOBALS['plan_your_day_test_unique_id'];
+		}
+	}
+}
+
+namespace Acodebeard\PlanYourDay\Tests {
+
+	use Acodebeard\PlanYourDay\Frontend\FrontendAssets;
+	use Acodebeard\PlanYourDay\Frontend\PlannerBlock;
+	use Acodebeard\PlanYourDay\Frontend\PlannerRenderer;
+	use Acodebeard\PlanYourDay\Google\GoogleApiClientInterface;
+	use Acodebeard\PlanYourDay\Planner\CategoryCatalog;
+	use Acodebeard\PlanYourDay\Planner\DistanceFormatter;
+	use Acodebeard\PlanYourDay\Planner\MapUrlBuilder;
+	use Acodebeard\PlanYourDay\Planner\PlannerPayloadBuilder;
+	use Acodebeard\PlanYourDay\Planner\PlannerStateBuilder;
+	use Acodebeard\PlanYourDay\Planner\RequestStateParser;
+	use Acodebeard\PlanYourDay\Planner\StartContextResolver;
+	use Acodebeard\PlanYourDay\Planner\WaypointList;
+	use Acodebeard\PlanYourDay\Security\RequestOriginValidator;
+	use Acodebeard\PlanYourDay\Security\VisitorTokenManager;
+	use Acodebeard\PlanYourDay\Settings\Settings;
+	use PHPUnit\Framework\TestCase;
+
+	final class PlannerBlockTest extends TestCase {
+		protected function setUp(): void {
+			parent::setUp();
+
+			$GLOBALS['plan_your_day_test_registered_blocks']   = [];
+			$GLOBALS['plan_your_day_test_enqueued_styles']     = [];
+			$GLOBALS['plan_your_day_test_enqueued_scripts']    = [];
+			$GLOBALS['plan_your_day_test_unique_id']           = 0;
+			$GLOBALS['plan_your_day_test_options']             = [];
+			$_COOKIE                                           = [
+				'plan_your_day_visitor' => str_repeat( 'ab', 24 ),
+			];
+			$_GET                                              = [];
+
+			if ( ! defined( 'PLAN_YOUR_DAY_VERSION' ) ) {
+				define( 'PLAN_YOUR_DAY_VERSION', 'test-version' );
+			}
+
+			if ( ! defined( 'PLAN_YOUR_DAY_PLUGIN_DIR' ) ) {
+				define( 'PLAN_YOUR_DAY_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+			}
+		}
+
+		public function test_register_uses_block_metadata_with_render_callback(): void {
+			$block = new PlannerBlock( $this->build_renderer(), new FrontendAssets() );
+
+			$block->register();
+
+			self::assertCount( 1, $GLOBALS['plan_your_day_test_registered_blocks'] );
+			self::assertSame(
+				PLAN_YOUR_DAY_PLUGIN_DIR . 'blocks/planner',
+				$GLOBALS['plan_your_day_test_registered_blocks'][0]['path']
+			);
+			self::assertSame(
+				[ $block, 'render' ],
+				$GLOBALS['plan_your_day_test_registered_blocks'][0]['args']['render_callback'] ?? null
+			);
+		}
+
+		public function test_render_enqueues_frontend_assets_and_uses_shared_renderer_output(): void {
+			$GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ] = Settings::sanitize(
+				array_merge(
+					Settings::defaults(),
+					[
+						'default_location_label'   => 'Downtown',
+						'default_location_address' => '123 Main St',
+					]
+				)
+			);
+
+			$block  = new PlannerBlock( $this->build_renderer(), new FrontendAssets() );
+			$output = $block->render(
+				[
+					'actionUrl' => 'https://example.test/planner',
+				]
+			);
+
+			self::assertArrayHasKey( FrontendAssets::STYLE_HANDLE, $GLOBALS['plan_your_day_test_enqueued_styles'] );
+			self::assertArrayHasKey( FrontendAssets::SCRIPT_HANDLE, $GLOBALS['plan_your_day_test_enqueued_scripts'] );
+			self::assertStringContainsString( 'class="plan-your-day"', $output );
+			self::assertStringContainsString( 'action="https://example.test/planner#plan-your-day-1"', $output );
+		}
+
+		private function build_renderer(): PlannerRenderer {
+			$settings             = new Settings();
+			$category_catalog     = new CategoryCatalog( $settings );
+			$waypoint_list        = new WaypointList( $settings );
+			$request_state_parser = new RequestStateParser( $waypoint_list );
+			$planner_state_builder = new PlannerStateBuilder(
+				$settings,
+				$category_catalog,
+				$this->createMock( GoogleApiClientInterface::class ),
+				$waypoint_list,
+				new StartContextResolver( $settings ),
+				new MapUrlBuilder(),
+				new DistanceFormatter( $settings ),
+				new RequestOriginValidator()
+			);
+
+			return new PlannerRenderer(
+				$settings,
+				$category_catalog,
+				$request_state_parser,
+				$planner_state_builder,
+				new PlannerPayloadBuilder( $settings ),
+				new VisitorTokenManager()
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a dynamic `plan-your-day/planner` block wrapper that renders through the existing shared planner renderer
- register a small editor-only block script and block metadata without introducing a new build pipeline
- extend frontend asset and block tests to cover registration and render behavior

## Why
Issue #28 called for a block editor entry point that uses the same frontend planner output as the shortcode. The plugin already had a shared renderer, so the missing work was wiring a server-rendered block around it without forking behavior or loading planner assets globally.

## Impact
Editors can now insert the planner from the block editor while the frontend continues to use the same renderer, settings, and interaction assets as the shortcode. Frontend assets still enqueue only when a planner instance actually renders.

## Validation
- `node --check plugin/plan-your-day/assets/js/plan-block.js`
- `composer test`

Closes #28.
