### PR TITLE
[codex] Finish release bookkeeping and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,18 @@ The plugin is under active development. Completed foundation work includes:
   labels, map URLs, start context, request state, and request-origin checks.
 - Shortcode-based frontend rendering with plugin-scoped assets and a shared
   planner renderer.
+- Block-editor rendering through a thin server-rendered wrapper around the
+  shared planner renderer.
 - WordPress REST browse/route endpoints with POST-only requests, guest-safe
   visitor token validation, same-site request checks, trusted-proxy-aware client
   IP resolution, and file-backed rate limiting.
 - Frontend JavaScript that updates browse and trip state through REST instead of
   full-page planner reloads.
+- Admin-editable categories, admin-editable interface copy, cache-clear tools,
+  and a Google API test tool.
 
-CI, block-editor support, configurable categories/copy, and production
-documentation are still tracked in GitHub issues.
+Browser automation and broader production QA are still tracked in GitHub
+issues.
 
 ## Requirements
 
@@ -48,14 +52,14 @@ documentation are still tracked in GitHub issues.
 - `plugin/plan-your-day/src/Admin/` contains the settings UI.
 - `plugin/plan-your-day/src/Google/` contains Google API client and cache
   classes.
-- `docs/` contains installation, architecture, settings, security,
-  troubleshooting, and planning notes for the plugin.
+- `docs/` contains installation, usage, admin, release, architecture, settings,
+  security, troubleshooting, and historical planning notes for the plugin.
 
 ## Documentation
 
 Start with [docs/README.md](docs/README.md). Current docs cover installation,
-architecture, settings, security, and troubleshooting for the work implemented
-so far.
+frontend usage, admin workflows, release steps, architecture, settings,
+security, and troubleshooting.
 
 ## Local Source Installation
 
@@ -87,6 +91,9 @@ installs production-only Composer autoload files into a temporary staging copy,
 and packages the final artifact with a top-level `plan-your-day/` directory
 suitable for **Plugins > Add New > Upload Plugin**.
 
+See [docs/RELEASES.md](docs/RELEASES.md) for the full manual GitHub release
+workflow and the metadata that needs to stay aligned.
+
 ## Configuration
 
 Plugin settings are stored in the `plan_your_day_settings` option and are
@@ -114,8 +121,9 @@ Server-side Google API keys must not be exposed to frontend runtime config.
 - Do not rely on PHP sessions in plugin code.
 - Use WordPress-native APIs for escaping, sanitization, options, REST,
   transients/object cache, HTTP requests, and asset registration.
-- Update `docs/PLAN-YOUR-DAY-PLUGIN-TODO.md` and GitHub issues as migration
-  work lands.
+- Treat `docs/PLAN-YOUR-DAY-PLUGIN-TODO.md` and
+  `docs/PLAN-YOUR-DAY-PLUGIN-ISSUES.md` as historical planning notes unless
+  they are explicitly refreshed.
 
 ## Useful Checks
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,0 +1,136 @@
+# Admin Workflows
+
+Plan Your Day settings live under:
+
+```text
+Settings > Plan Your Day
+```
+
+Only administrators with `manage_options` can change plugin settings or run the
+admin-only tools.
+
+## Recommended Setup Order
+
+1. Fill in the required default location fields.
+2. Add the Google API keys your site needs.
+3. Save planner behavior settings.
+4. Review categories and interface copy.
+5. Save changes.
+6. Run the Google API test.
+
+## Settings Sections
+
+### Default Location
+
+Use this section to define the stable starting area for the planner.
+
+Required:
+
+- default location label
+- default location address or search phrase
+
+Optional:
+
+- latitude
+- longitude
+- Google Place ID
+
+The saved location is used for frontend defaults, search biasing, and other
+planner state derived from the configured start area.
+
+### Planner Behavior
+
+This section controls the main visitor-facing planner behavior:
+
+- allowed start modes
+- max waypoints
+- result count
+- distance unit
+- map preview toggle
+- Google Maps handoff toggle
+
+### Interface Copy
+
+This section manages the editable frontend labels, helper text, buttons,
+messages, and accessible text used by the planner.
+
+Important behavior:
+
+- required labels fall back to plugin defaults when saved blank
+- optional helper text can be blanked intentionally
+- the same saved/default copy is used in the initial HTML and the frontend
+  runtime config
+
+### Categories
+
+This section manages the saved category buttons shown to visitors.
+
+Each category row includes:
+
+- label
+- description
+- Google search query
+- enabled state
+- sort order
+
+The starter category fallback setting controls whether fresh or empty installs
+show the built-in generic starter rows instead of no category buttons.
+
+## Google API And Cache
+
+### Google API
+
+Use this section to save:
+
+- Maps Embed API key
+- Places API key
+- optional Geocoding API key
+- API timeout
+
+Server-side keys stay on the server and are not exposed in frontend runtime
+config.
+
+### Google API Cache
+
+Use this section to tune the cache TTL values for:
+
+- text search responses
+- place details responses
+- geocoding responses
+
+Set a TTL to `0` to disable that cache path.
+
+## Security And Network Settings
+
+### Rate Limiting
+
+Use `Requests per minute` to control the public REST rate limiter budget used by
+the planner browse and route endpoints.
+
+### Advanced
+
+Use `Trusted proxy CIDRs` when the site sits behind a known reverse proxy or
+load balancer and forwarded client IP handling needs to trust specific proxy
+ranges.
+
+## Admin Tools
+
+### Cache Tools
+
+The settings page includes admin-only cache controls for Google API responses:
+
+- clear the full Google API cache
+- clear one cache scope
+- clear one Google Place ID
+
+Use these after changing cache TTL settings, troubleshooting unexpected results,
+or forcing a fresh provider read.
+
+### Google API Test
+
+The `Run Google API test` button performs a lightweight admin-only probe using
+the configured default location, categories, and server-side keys.
+
+After the test runs, the settings page shows the latest probe summary and
+individual results so you can confirm whether the current configuration is
+usable before testing the public planner.

--- a/docs/PLAN-YOUR-DAY-PLUGIN-ISSUES.md
+++ b/docs/PLAN-YOUR-DAY-PLUGIN-ISSUES.md
@@ -1,5 +1,9 @@
 # Plan Your Day Plugin GitHub Issue Drafts
 
+> Historical planning snapshot: these issue drafts were prepared before the
+> implementation backlog moved into GitHub. They are preserved for context, not
+> maintained as the current source of truth for feature status.
+
 ## Issue 1
 
 Title: Create generic WordPress plugin scaffold

--- a/docs/PLAN-YOUR-DAY-PLUGIN-TODO.md
+++ b/docs/PLAN-YOUR-DAY-PLUGIN-TODO.md
@@ -1,5 +1,10 @@
 # Plan Your Day Plugin TODO
 
+> Historical planning snapshot: this checklist was drafted during the early
+> plugin port and backlog planning work. It is not maintained as the live
+> implementation-status document. Use current GitHub Issues and the repo docs
+> for current status.
+
 ## Overview
 
 Continue hardening Plan Your Day as a generic, maintainable WordPress plugin.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,19 @@
 
 This directory documents the WordPress plugin as it exists today. The plugin is
 installable and has admin/settings, Google API, cache, planner helper, planner
-state, frontend rendering, REST endpoints, assets, and release zip packaging
-in place. Production QA is still in progress.
+state, shortcode and block rendering, REST endpoints, assets, and release zip
+packaging in place. Broader production QA automation is still in progress.
 
 ## Current Documents
 
 - [Installation](INSTALLATION.md): source checkout setup, local WordPress test install,
   activation checks, and release zip build/install steps.
+- [Frontend Usage](USAGE.md): shortcode and block placement, supported
+  entry-point settings, and frontend placement guidance.
+- [Admin Workflows](ADMIN.md): settings-page sections, setup order, cache
+  tools, and the Google API test workflow.
+- [Release Process](RELEASES.md): version metadata alignment, changelog
+  expectations, and the manual GitHub release zip workflow.
 - [Architecture](ARCHITECTURE.md): plugin layers, current service boundaries,
   and current runtime structure.
 - [Settings](SETTINGS.md): option name, settings groups, defaults, API keys,
@@ -23,9 +29,14 @@ in place. Production QA is still in progress.
 These topics are intentionally incomplete until their implementation issues
 land:
 
-- Editor and frontend usage documentation.
-- Shortcode and block instructions.
 - REST endpoint request/response reference.
 - Anonymous visitor token details.
-- Changelog policy.
 - Production QA and accessibility notes.
+
+## Historical Planning Notes
+
+These files are preserved as planning snapshots, not as the current source of
+truth for implementation status:
+
+- [Plugin TODO Snapshot](PLAN-YOUR-DAY-PLUGIN-TODO.md)
+- [GitHub Issue Draft Snapshot](PLAN-YOUR-DAY-PLUGIN-ISSUES.md)

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,66 @@
+# Release Process
+
+Plan Your Day v1 ships as a manual GitHub release zip. The plugin does not
+include a private updater or a custom `Update URI` workflow right now.
+
+## Release Metadata
+
+Keep these values aligned before building a release:
+
+- plugin header `Version` in `plugin/plan-your-day/plan-your-day.php`
+- `PLAN_YOUR_DAY_VERSION`
+- `PLAN_YOUR_DAY_SCHEMA_VERSION`
+- `plugin/plan-your-day/release.json`
+- the artifact filename in `release.json`
+- the `Unreleased` and versioned entries in `plugin/plan-your-day/readme.txt`
+
+The release builder validates that:
+
+- `release.json.version` matches `PLAN_YOUR_DAY_VERSION`
+- `release.json.schemaVersion` matches `PLAN_YOUR_DAY_SCHEMA_VERSION`
+- the artifact filename matches the plugin slug and version
+
+## Standard Release Steps
+
+1. Update the plugin version metadata and changelog entries.
+2. Run the plugin test suite:
+
+   ```sh
+   cd plugin/plan-your-day
+   composer test
+   ```
+
+3. Build the installable release zip:
+
+   ```sh
+   cd plugin/plan-your-day
+   ./tools/build-release-zip.sh
+   ```
+
+4. Confirm the artifact was created at the path defined in `release.json`.
+5. Smoke-test the built zip in a WordPress install when the release includes
+   user-facing or upgrade-sensitive changes.
+6. Create the Git tag and GitHub release, then attach or publish the built zip.
+
+## Installable Artifact
+
+The current release artifact is an installable WordPress admin zip with:
+
+- a top-level `plan-your-day/` directory
+- production Composer autoload files included
+- development-only files excluded through `.distignore`
+
+Production sites should install the built zip and should not need to run
+Composer on the server.
+
+## Update Expectations
+
+Current update flow:
+
+- build a new release zip from this source repository
+- publish it through GitHub Releases
+- install or replace it manually on the target WordPress site
+
+If the project later adds a private updater or `Update URI` support, that
+should land under a separate Issue rather than expanding the current manual
+release process silently.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -41,8 +41,10 @@ defaults.
   used when the frontend requests additional Google Places pages through the
   More Results control.
 - `distance_unit`: `miles` or `kilometers`.
-- `map_preview_enabled`: allows future on-page Maps Embed previews.
-- `maps_handoff_enabled`: allows future outbound Google Maps links.
+- `map_preview_enabled`: controls whether the public planner may render on-page
+  Google Maps Embed previews.
+- `maps_handoff_enabled`: controls whether the public planner may show outbound
+  Google Maps links.
 
 ## Categories
 
@@ -147,10 +149,11 @@ TTL values can be set to `0` to disable that cache path.
 
 ## Rate Limit And Trusted Proxies
 
-- `rate_limit_per_minute`: stored configuration for the future public endpoint
-  rate limiter.
-- `trusted_proxy_cidrs`: optional IP/CIDR list, one per line, for future
-  trusted-proxy-aware client IP resolution.
+- `rate_limit_per_minute`: per-minute budget used by the active public planner
+  REST rate limiter.
+- `trusted_proxy_cidrs`: optional IP/CIDR list, one per line, used for
+  trusted-proxy-aware client IP resolution when the site sits behind known
+  reverse proxies.
 
 Invalid trusted proxy entries are discarded during sanitization.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,93 @@
+# Frontend Usage
+
+Plan Your Day can be rendered through either the block editor or the shortcode.
+Both entry points use the same server-rendered planner and the same frontend
+CSS and JavaScript assets.
+
+## Before You Place The Planner
+
+Make sure the plugin has been configured under:
+
+```text
+Settings > Plan Your Day
+```
+
+At minimum, set:
+
+- the default location label
+- the default location address or search phrase
+- the Google API keys needed for your site
+
+If those required settings are missing, the frontend renders a setup notice
+instead of the full planner.
+
+## Block Editor
+
+The plugin registers a dynamic block named:
+
+```text
+Plan Your Day
+```
+
+Editor behavior:
+
+- Insert the block from the block inserter.
+- The editor shows a placeholder instead of trying to run the full planner UI
+  inside Gutenberg.
+- The actual planner is rendered on the frontend by the same shared renderer
+  used by the shortcode.
+
+Block setting:
+
+- `Action URL`: optional page URL used for form submissions and stateful links.
+  Leave it blank to submit back to the current page.
+
+Use the block when the page is already built in Gutenberg and you want editors
+to place the planner without writing shortcode manually.
+
+## Shortcode
+
+The shortcode tag is:
+
+```text
+[plan_your_day]
+```
+
+Supported attributes:
+
+- `action_url`: optional page URL used for form submissions and stateful links.
+  Leave it blank to submit back to the current page.
+
+Examples:
+
+```text
+[plan_your_day]
+```
+
+```text
+[plan_your_day action_url="https://example.test/plan-your-day/"]
+```
+
+Use the shortcode in classic content, a Shortcode block, widget areas that
+allow shortcodes, or any other editor flow where you want explicit markup
+control.
+
+## Placement Guidance
+
+- Place the planner on a dedicated page or a section with enough vertical space
+  for results and trip management.
+- Current QA focuses on the common one-planner-per-page case. If you need
+  multiple planners on one page, test that layout carefully in your theme.
+- Frontend assets are registered globally but only enqueue when the shortcode
+  or block actually renders.
+
+## What Visitors Can Do
+
+With a configured planner, visitors can:
+
+- choose a starting mode such as default, custom, or current-location handoff
+- browse built-in or saved categories
+- run custom place searches
+- add, remove, clear, and reorder waypoints
+- request more results for category or custom searches
+- view the route preview and open Google Maps handoff links when enabled

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -15,11 +15,10 @@ A configurable day planning plugin for WordPress.
 Plan Your Day is a configurable day planning plugin for WordPress.
 
 Current development builds include the plugin scaffold, Settings API
-registration, admin settings screen, Google API client abstraction, Google API
-caching, frontend planner rendering, REST endpoints, and extracted planner
-helper services.
-
-Block wrapper polish and production QA are still in progress.
+registration, admin settings screen, editable categories and interface copy,
+Google API client abstraction, Google API caching, frontend planner rendering,
+block and shortcode entry points, REST endpoints, and extracted planner helper
+services.
 
 == Installation ==
 
@@ -48,10 +47,11 @@ Current settings include:
 * Default location label, address/search phrase, latitude, longitude, and Place ID.
 * Allowed start modes, max waypoints, result count, distance unit, map preview,
   and Google Maps handoff toggles.
+* Editable categories and interface copy.
 * Browser-facing Maps Embed API key.
 * Server-side Places and Geocoding API keys.
 * Google API timeout and cache TTLs.
-* Rate-limit value and trusted proxy CIDRs for future endpoint protection.
+* Rate-limit value and trusted proxy CIDRs for public endpoint protection.
 
 == External services ==
 
@@ -91,18 +91,24 @@ Not yet. The plugin is installable and includes the planner frontend, REST
 endpoints, and admin/settings flow, but production QA and release hardening are
 still in progress.
 
+= How do I display the planner? =
+
+Use the Plan Your Day block in the block editor or add `[plan_your_day]` to a
+page, post, or Shortcode block. The repository docs cover placement guidance
+and the optional `action_url` / `Action URL` setting.
+
 = Where is the developer documentation? =
 
-See the repository `docs/` directory for installation, architecture, settings,
-security, and troubleshooting notes.
+See the repository `docs/` directory for installation, usage, admin, release,
+architecture, settings, security, and troubleshooting notes.
 
 == Changelog ==
 
 = Unreleased =
-* Added Settings API registration and admin settings screen.
-* Added Google API client abstraction and transient-backed caching.
-* Added extracted planner helper services for shortcode and REST work.
-* Added a reproducible release zip builder for WordPress admin installs.
+* Added block-editor and shortcode entry points that share the same planner renderer.
+* Added admin-editable categories and interface copy settings.
+* Added REST-powered planner interactions, rate limiting, and Google API admin tools.
+* Added a reproducible release zip builder and manual release-process documentation.
 
 = 0.1.0 =
 * Initial plugin scaffold (GH issue #20): directory structure, main plugin file, activation / deactivation hooks, uninstall routine, PSR-4 autoloading.

--- a/plugin/plan-your-day/release.json
+++ b/plugin/plan-your-day/release.json
@@ -2,7 +2,7 @@
     "name": "Plan Your Day",
     "slug": "plan-your-day",
     "version": "0.1.0",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "artifact": "../../dist/plan-your-day-0.1.0.zip",
     "distribution": "github-release-zip",
     "notes": "Installable WordPress admin zip built from this source repository with Composer production autoload files included."

--- a/plugin/plan-your-day/src/Admin/SettingsPage.php
+++ b/plugin/plan-your-day/src/Admin/SettingsPage.php
@@ -96,7 +96,7 @@ final class SettingsPage {
 		$this->add_field(
 			'default_location_place_id',
 			__( 'Default Google Place ID', 'plan-your-day' ),
-			__( 'Optional. Google Place ID for the default location when a future workflow needs exact place details.', 'plan-your-day' ),
+			__( 'Optional. Save the exact Google Place ID for the default location when you want a stable place reference alongside the address.', 'plan-your-day' ),
 			'text',
 			[],
 			'plan_your_day_default_location'
@@ -158,7 +158,7 @@ final class SettingsPage {
 		$this->add_field(
 			'map_preview_enabled',
 			__( 'Map preview', 'plan-your-day' ),
-			__( 'Allow on-page Google Maps preview rendering when the frontend is added.', 'plan-your-day' ),
+			__( 'Allow on-page Google Maps preview rendering in the public planner.', 'plan-your-day' ),
 			'checkbox',
 			[],
 			'plan_your_day_planner_behavior'
@@ -167,7 +167,7 @@ final class SettingsPage {
 		$this->add_field(
 			'maps_handoff_enabled',
 			__( 'Google Maps handoff', 'plan-your-day' ),
-			__( 'Allow outbound Google Maps links when the frontend is added.', 'plan-your-day' ),
+			__( 'Allow outbound Google Maps links from the public planner.', 'plan-your-day' ),
 			'checkbox',
 			[],
 			'plan_your_day_planner_behavior'

--- a/plugin/plan-your-day/src/Settings/Settings.php
+++ b/plugin/plan-your-day/src/Settings/Settings.php
@@ -377,6 +377,8 @@ final class Settings {
 	}
 
 	public function maybe_upgrade(): void {
+		$this->maybe_update_stored_plugin_version();
+
 		$current_schema_version = (int) get_option( 'plan_your_day_schema_version', 0 );
 
 		if ( $current_schema_version >= self::EDITABLE_CATEGORY_SCHEMA_VERSION ) {
@@ -399,6 +401,20 @@ final class Settings {
 		update_option( self::OPTION_NAME, self::sanitize( array_merge( self::defaults(), $settings ) ) );
 
 		return true;
+	}
+
+	private function maybe_update_stored_plugin_version(): void {
+		if ( ! defined( 'PLAN_YOUR_DAY_VERSION' ) ) {
+			return;
+		}
+
+		$current_version = get_option( 'plan_your_day_version', '' );
+
+		if ( PLAN_YOUR_DAY_VERSION === $current_version ) {
+			return;
+		}
+
+		update_option( 'plan_your_day_version', PLAN_YOUR_DAY_VERSION );
 	}
 
 	public function get_missing_required_settings(): array {

--- a/plugin/plan-your-day/tests/SettingsTest.php
+++ b/plugin/plan-your-day/tests/SettingsTest.php
@@ -187,13 +187,26 @@ final class SettingsTest extends TestCase {
 
 	public function test_maybe_upgrade_seeds_default_categories_and_updates_schema_version_for_existing_empty_installs(): void {
 		update_option( Settings::OPTION_NAME, Settings::defaults() );
+		update_option( 'plan_your_day_version', '0.0.1' );
 		update_option( 'plan_your_day_schema_version', 1 );
 
 		$settings = new Settings();
 		$settings->maybe_upgrade();
 
+		self::assertSame( PLAN_YOUR_DAY_VERSION, get_option( 'plan_your_day_version' ) );
 		self::assertSame( Settings::default_categories(), get_option( Settings::OPTION_NAME )['categories'] ?? [] );
-		self::assertSame( 2, get_option( 'plan_your_day_schema_version' ) );
+		self::assertSame( PLAN_YOUR_DAY_SCHEMA_VERSION, get_option( 'plan_your_day_schema_version' ) );
+	}
+
+	public function test_maybe_upgrade_updates_stored_plugin_version_even_when_schema_is_current(): void {
+		update_option( 'plan_your_day_version', '0.0.9' );
+		update_option( 'plan_your_day_schema_version', PLAN_YOUR_DAY_SCHEMA_VERSION );
+
+		$settings = new Settings();
+		$settings->maybe_upgrade();
+
+		self::assertSame( PLAN_YOUR_DAY_VERSION, get_option( 'plan_your_day_version' ) );
+		self::assertSame( PLAN_YOUR_DAY_SCHEMA_VERSION, get_option( 'plan_your_day_schema_version' ) );
 	}
 
 	public function test_sanitize_trusted_proxy_cidrs_accepts_ipv4_and_ipv6_edge_masks(): void {

--- a/plugin/plan-your-day/tests/bootstrap.php
+++ b/plugin/plan-your-day/tests/bootstrap.php
@@ -9,6 +9,14 @@ if ( ! defined( 'PLAN_YOUR_DAY_TEXT_DOMAIN' ) ) {
 	define( 'PLAN_YOUR_DAY_TEXT_DOMAIN', 'plan-your-day' );
 }
 
+if ( ! defined( 'PLAN_YOUR_DAY_VERSION' ) ) {
+	define( 'PLAN_YOUR_DAY_VERSION', 'test-version' );
+}
+
+if ( ! defined( 'PLAN_YOUR_DAY_SCHEMA_VERSION' ) ) {
+	define( 'PLAN_YOUR_DAY_SCHEMA_VERSION', 2 );
+}
+
 if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
 	define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
 }

--- a/plugin/plan-your-day/tools/build-release-zip.sh
+++ b/plugin/plan-your-day/tools/build-release-zip.sh
@@ -22,14 +22,54 @@ if ! command -v rsync >/dev/null 2>&1; then
 fi
 
 read_release_meta() {
-	php -r '
-		$release = json_decode(file_get_contents($argv[1]), true);
-		if (!is_array($release) || empty($release["slug"]) || empty($release["version"]) || empty($release["artifact"])) {
-			fwrite(STDERR, "release.json must contain non-empty slug, version, and artifact values.\n");
-			exit(1);
-		}
-		echo $release["slug"], "\n", $release["version"], "\n", $release["artifact"], "\n";
-	' "$RELEASE_JSON"
+	php /dev/stdin "$RELEASE_JSON" "${PLUGIN_DIR}/plan-your-day.php" <<'PHP'
+<?php
+$release = json_decode(file_get_contents($argv[1]), true);
+$plugin  = file_get_contents($argv[2]);
+
+if ( ! is_array( $release ) || empty( $release['slug'] ) || empty( $release['version'] ) || ! isset( $release['schemaVersion'] ) || empty( $release['artifact'] ) ) {
+	fwrite( STDERR, "release.json must contain non-empty slug, version, schemaVersion, and artifact values.\n" );
+	exit( 1 );
+}
+
+if ( ! is_string( $plugin ) || '' === $plugin ) {
+	fwrite( STDERR, "Unable to read the main plugin file.\n" );
+	exit( 1 );
+}
+
+if ( ! preg_match( "/define\\(\\s*'PLAN_YOUR_DAY_VERSION'\\s*,\\s*'([^']+)'\\s*\\)/", $plugin, $version_match ) ) {
+	fwrite( STDERR, "Unable to read PLAN_YOUR_DAY_VERSION from the main plugin file.\n" );
+	exit( 1 );
+}
+
+if ( ! preg_match( "/define\\(\\s*'PLAN_YOUR_DAY_SCHEMA_VERSION'\\s*,\\s*(\\d+)\\s*\\)/", $plugin, $schema_match ) ) {
+	fwrite( STDERR, "Unable to read PLAN_YOUR_DAY_SCHEMA_VERSION from the main plugin file.\n" );
+	exit( 1 );
+}
+
+$runtime_version = $version_match[1];
+$runtime_schema  = (int) $schema_match[1];
+$release_schema  = (int) $release['schemaVersion'];
+$artifact_name   = basename( $release['artifact'] );
+$expected_name   = sprintf( '%s-%s.zip', $release['slug'], $release['version'] );
+
+if ( $release['version'] !== $runtime_version ) {
+	fwrite( STDERR, "release.json version must match PLAN_YOUR_DAY_VERSION.\n" );
+	exit( 1 );
+}
+
+if ( $release_schema !== $runtime_schema ) {
+	fwrite( STDERR, "release.json schemaVersion must match PLAN_YOUR_DAY_SCHEMA_VERSION.\n" );
+	exit( 1 );
+}
+
+if ( $artifact_name !== $expected_name ) {
+	fwrite( STDERR, "release.json artifact name must match the plugin slug and version.\n" );
+	exit( 1 );
+}
+
+echo $release['slug'], "\n", $release['version'], "\n", $release['artifact'], "\n";
+PHP
 }
 
 mapfile -t RELEASE_META < <(read_release_meta)


### PR DESCRIPTION
## Summary
- update upgrade bookkeeping so the stored plugin version is refreshed during normal plugin upgrades
- align release metadata and harden the release builder so version, schema, and artifact naming stay in sync
- add dedicated frontend usage, admin workflow, and release-process docs while reconciling stale README and settings language

## Why
Issue #35 still had two real gaps: `release.json` was out of sync with the runtime schema version, and `plan_your_day_version` only updated on activation instead of normal upgrades. Issue #39 had become the main documentation drift bucket, with current docs still describing shipped features such as block support, editable categories/copy, and active endpoint protections as future work.

## Impact
Release metadata is now validated by the build script before an installable zip is created, and existing installs will refresh the stored plugin version during normal upgrade execution. The docs now cover shortcode usage, block usage, admin settings workflows, cache and Google API tools, and the manual GitHub release zip process, while stale planning docs are clearly marked as historical snapshots.

## Validation
- `composer test`
- `./tools/build-release-zip.sh`

Closes #35.
Closes #39.
