### PR TITLE
Harden Google geocode failure handling

### DIFF
--- a/.github/workflows/plugin-quality.yml
+++ b/.github/workflows/plugin-quality.yml
@@ -128,7 +128,23 @@ jobs:
           }
           EOF
 
-          npm -g --no-fund install @wordpress/env@11.5.0
+          wp_env_tools="$RUNNER_TEMP/wp-env-tools"
+          mkdir -p "$wp_env_tools"
+          cat > "$wp_env_tools/package.json" <<'EOF'
+          {
+            "private": true,
+            "dependencies": {
+              "@wordpress/env": "11.5.0"
+            },
+            "overrides": {
+              "rimraf": {
+                "glob": "^13.0.6"
+              }
+            }
+          }
+          EOF
+          npm --prefix "$wp_env_tools" --no-audit --no-fund install
+          export PATH="$wp_env_tools/node_modules/.bin:$PATH"
           command -v wp-env
           wp-env --version
           cat .wp-env.json
@@ -170,6 +186,7 @@ jobs:
         env:
           WP_ENV_HOME: ${{ runner.temp }}/wp-env
         run: |
+          export PATH="$RUNNER_TEMP/wp-env-tools/node_modules/.bin:$PATH"
           if command -v wp-env >/dev/null 2>&1; then
             wp-env destroy --force || true
           fi

--- a/.github/workflows/plugin-quality.yml
+++ b/.github/workflows/plugin-quality.yml
@@ -104,9 +104,72 @@ jobs:
           working-directory: plugin/plan-your-day
           composer-options: "--no-dev --optimize-autoloader"
 
-      - uses: wordpress/plugin-check-action@v1
+      - uses: actions/setup-node@v4
         with:
-          build-dir: ./plugin/plan-your-day
-          exclude-directories: tests,tools
-          exclude-files: .distignore,DECISIONS.md,phpcs.xml.dist,phpunit.xml.dist
-          ignore-warnings: true
+          node-version: "22"
+
+      - name: Run Plugin Check
+        env:
+          WP_ENV_HOME: ${{ runner.temp }}/wp-env
+        run: |
+          trap 'status=$?; if [ "$status" -ne 0 ]; then docker ps -a || true; find "$WP_ENV_HOME" -maxdepth 3 -type f -print || true; fi; exit "$status"' EXIT
+
+          plugin_dir="$(realpath ./plugin/plan-your-day)"
+
+          cat > .wp-env.json <<EOF
+          {
+            "core": null,
+            "port": 8880,
+            "testsEnvironment": false,
+            "plugins": [ "https://downloads.wordpress.org/plugin/plugin-check.zip" ],
+            "mappings": {
+              "wp-content/plugins/plan-your-day": "$plugin_dir"
+            }
+          }
+          EOF
+
+          npm -g --no-fund install @wordpress/env@11.5.0
+          command -v wp-env
+          wp-env --version
+          cat .wp-env.json
+          wp-env start --update
+          wp-env run cli wp cli info
+          wp-env run cli wp plugin list
+          wp-env run cli wp plugin list-checks
+          wp-env run cli wp plugin list-check-categories
+
+          wp-env run cli wp plugin activate plan-your-day
+
+          set +e
+          wp-env run cli wp plugin check plan-your-day \
+            --format=json \
+            --ignore-warnings \
+            --exclude-files=.distignore,DECISIONS.md,phpcs.xml.dist,phpunit.xml.dist,.wp-env.json \
+            --exclude-directories=tests,tools \
+            --require=./wp-content/plugins/plugin-check/cli.php \
+            > "$RUNNER_TEMP/plugin-check-results.txt"
+          status=$?
+          set -e
+
+          cat "$RUNNER_TEMP/plugin-check-results.txt"
+          if grep -Eq '"type"[[:space:]]*:[[:space:]]*"ERROR"' "$RUNNER_TEMP/plugin-check-results.txt"; then
+            exit 1
+          fi
+
+          exit "$status"
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: plugin-check-results
+          path: ${{ runner.temp }}/plugin-check-results.txt
+          if-no-files-found: ignore
+
+      - name: Stop wp-env
+        if: ${{ always() }}
+        env:
+          WP_ENV_HOME: ${{ runner.temp }}/wp-env
+        run: |
+          if command -v wp-env >/dev/null 2>&1; then
+            wp-env destroy --force || true
+          fi

--- a/plugin/plan-your-day/readme.txt
+++ b/plugin/plan-your-day/readme.txt
@@ -2,7 +2,7 @@
 Contributors: acodebeard
 Tags: planning, maps, wayfinding
 Requires at least: 6.8
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.2
 Stable tag: 0.5
 License: GPLv2 or later

--- a/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/CachedGoogleApiClient.php
@@ -9,6 +9,11 @@ defined( 'ABSPATH' ) || exit;
 
 final class CachedGoogleApiClient implements GoogleApiClientInterface {
 	private const RETRYABLE_FAILURE_CACHE_TTL = 30;
+	private const COOLDOWN_FAILURE_CODES = [
+		'geocoding_quota_exceeded' => true,
+		'geocoding_request_denied' => true,
+		'geocoding_zero_results'   => true,
+	];
 	private GoogleApiClientInterface $client;
 	private Settings $settings;
 	private GoogleApiCache $cache;
@@ -96,8 +101,8 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	private function remember( string $cache_key, int $ttl, string $scope, string $place_id, callable $callback ): GoogleApiResult {
-		// Retryable failures use a short cooldown cache even when the normal success TTL is disabled,
-		// so operators can disable success caching without reintroducing burst retries after 429/5xx responses.
+		// Failure cooldowns still apply when the normal success TTL is disabled,
+		// so operators can disable success caching without reintroducing provider retry bursts.
 		$cached = $this->cache->get( $cache_key );
 
 		if ( null !== $cached ) {
@@ -108,11 +113,15 @@ final class CachedGoogleApiClient implements GoogleApiClientInterface {
 
 		if ( $result->is_success() ) {
 			$this->cache->set( $cache_key, $result, $ttl, $scope, $place_id );
-		} elseif ( $result->is_retryable() ) {
+		} elseif ( $this->is_cooldown_failure( $result ) ) {
 			$this->cache->set( $cache_key, $result, self::RETRYABLE_FAILURE_CACHE_TTL, $scope, $place_id );
 		}
 
 		return $result;
+	}
+
+	private function is_cooldown_failure( GoogleApiResult $result ): bool {
+		return $result->is_retryable() || isset( self::COOLDOWN_FAILURE_CODES[ $result->error_code() ] );
 	}
 
 	private function normalize_coordinate( ?float $coordinate ): ?string {

--- a/plugin/plan-your-day/src/Google/GoogleApiClient.php
+++ b/plugin/plan-your-day/src/Google/GoogleApiClient.php
@@ -271,9 +271,13 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		$first    = is_array( $results[0] ?? null ) ? $results[0] : [];
 		$geometry = is_array( $first['geometry'] ?? null ) ? $first['geometry'] : [];
 		$location = is_array( $geometry['location'] ?? null ) ? $geometry['location'] : [];
+		$status   = strtoupper( trim( (string) ( $body['status'] ?? '' ) ) );
+
+		if ( 'OK' !== $status ) {
+			return $this->geocode_status_failure( $status, $decoded['status_code'] );
+		}
 
 		if (
-			'OK' !== (string) ( $body['status'] ?? '' ) ||
 			! isset( $location['lat'], $location['lng'] ) ||
 			! is_numeric( $location['lat'] ) ||
 			! is_numeric( $location['lng'] )
@@ -295,6 +299,59 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		);
 	}
 
+	private function geocode_status_failure( string $status, int $status_code ): GoogleApiResult {
+		$result = match ( $status ) {
+			'OVER_QUERY_LIMIT' => GoogleApiResult::failure(
+				'geocoding_rate_limited',
+				__( 'Google geocoding is rate limited right now.', 'plan-your-day' ),
+				$status_code,
+				true
+			),
+			'OVER_DAILY_LIMIT' => GoogleApiResult::failure(
+				'geocoding_quota_exceeded',
+				__( 'Google geocoding quota is unavailable right now.', 'plan-your-day' ),
+				$status_code,
+				false
+			),
+			'REQUEST_DENIED' => GoogleApiResult::failure(
+				'geocoding_request_denied',
+				__( 'Google geocoding is not allowed for this API key.', 'plan-your-day' ),
+				$status_code,
+				false
+			),
+			'UNKNOWN_ERROR' => GoogleApiResult::failure(
+				'geocoding_unavailable',
+				__( 'Google geocoding is unavailable right now.', 'plan-your-day' ),
+				$status_code,
+				true
+			),
+			'ZERO_RESULTS' => GoogleApiResult::failure(
+				'geocoding_zero_results',
+				__( 'Google geocoding could not find this address.', 'plan-your-day' ),
+				$status_code,
+				false
+			),
+			default => GoogleApiResult::failure(
+				'geocoding_unavailable',
+				__( 'Google geocoding is unavailable right now.', 'plan-your-day' ),
+				$status_code,
+				$this->is_retryable_status( $status_code )
+			),
+		};
+
+		DebugLogger::log(
+			'google.geocode.provider_status',
+			[
+				'status_code'     => $status_code,
+				'provider_status' => '' !== $status ? $status : 'missing',
+				'error_code'      => $result->error_code(),
+				'retryable'       => $result->is_retryable(),
+			]
+		);
+
+		return $result;
+	}
+
 	/**
 	 * @return array{body: array, status_code: int}|GoogleApiResult
 	 */
@@ -303,11 +360,11 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 			DebugLogger::log(
 				'google.response.wp_error',
 				[
-					'error_code' => $error_code,
-					'response'   => $response,
+					'error_code'    => $error_code,
+					'wp_error_code' => $response->get_error_code(),
 				]
 			);
-			return GoogleApiResult::failure( $error_code, $message );
+			return GoogleApiResult::failure( $error_code, $message, 0, true );
 		}
 
 		if ( ! is_array( $response ) ) {
@@ -322,7 +379,8 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 		}
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		$body        = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		$raw_body    = (string) wp_remote_retrieve_body( $response );
+		$body        = json_decode( $raw_body, true );
 
 		if ( $status_code < 200 || $status_code >= 300 || ! is_array( $body ) ) {
 			DebugLogger::log(
@@ -330,7 +388,8 @@ final class GoogleApiClient implements GoogleApiClientInterface {
 				[
 					'error_code'   => $error_code,
 					'status_code'  => $status_code,
-					'body_excerpt' => wp_remote_retrieve_body( $response ),
+					'body_length'  => strlen( $raw_body ),
+					'body_keys'    => is_array( $body ) ? array_keys( $body ) : [],
 				]
 			);
 			return GoogleApiResult::failure(

--- a/plugin/plan-your-day/tests/GoogleApiClientTest.php
+++ b/plugin/plan-your-day/tests/GoogleApiClientTest.php
@@ -97,6 +97,64 @@ final class GoogleApiClientTest extends TestCase {
 		self::assertSame( 'page-3', $result->data()['nextPageToken'] ?? '' );
 	}
 
+	public function test_geocode_classifies_provider_body_statuses(): void {
+		$cases = [
+			'OVER_QUERY_LIMIT' => [
+				'error_code' => 'geocoding_rate_limited',
+				'retryable'  => true,
+			],
+			'OVER_DAILY_LIMIT' => [
+				'error_code' => 'geocoding_quota_exceeded',
+				'retryable'  => false,
+			],
+			'REQUEST_DENIED'   => [
+				'error_code' => 'geocoding_request_denied',
+				'retryable'  => false,
+			],
+			'UNKNOWN_ERROR'    => [
+				'error_code' => 'geocoding_unavailable',
+				'retryable'  => true,
+			],
+			'ZERO_RESULTS'     => [
+				'error_code' => 'geocoding_zero_results',
+				'retryable'  => false,
+			],
+		];
+
+		foreach ( $cases as $provider_status => $expected ) {
+			$transport                    = new RecordingGoogleHttpTransport();
+			$transport->get_response_body = wp_json_encode(
+				[
+					'status'        => $provider_status,
+					'error_message' => 'Provider detail containing places-key must not be surfaced.',
+					'results'       => [],
+				]
+			);
+			$client                       = new GoogleApiClient( new Settings(), $transport, new PlaceParser() );
+
+			$result = $client->geocode( 'Unknown Test Address' );
+
+			self::assertFalse( $result->is_success(), $provider_status );
+			self::assertSame( $expected['error_code'], $result->error_code(), $provider_status );
+			self::assertSame( $expected['retryable'], $result->is_retryable(), $provider_status );
+			self::assertSame( 200, $result->status_code(), $provider_status );
+			self::assertStringNotContainsString( 'places-key', $result->message(), $provider_status );
+		}
+	}
+
+	public function test_geocode_transport_wp_error_failure_is_retryable(): void {
+		$transport               = new RecordingGoogleHttpTransport();
+		$transport->get_response = new \WP_Error( 'http_request_failed', 'Connection timed out while calling provider.' );
+		$client                  = new GoogleApiClient( new Settings(), $transport, new PlaceParser() );
+
+		$result = $client->geocode( '123 Test St' );
+
+		self::assertFalse( $result->is_success() );
+		self::assertSame( 'geocoding_unavailable', $result->error_code() );
+		self::assertSame( 0, $result->status_code() );
+		self::assertTrue( $result->is_retryable() );
+	}
+
 	public function test_cached_text_search_key_includes_request_shaping_settings(): void {
 		$cache            = new GoogleApiCache();
 		$recording_client = new RecordingGoogleApiClient();
@@ -198,22 +256,55 @@ final class GoogleApiClientTest extends TestCase {
 		self::assertSame( 1, $recording_client->text_search_calls );
 		self::assertNotEmpty( $GLOBALS['plan_your_day_test_transients'] );
 	}
+
+	public function test_cached_geocode_briefly_reuses_provider_cooldown_failure_results(): void {
+		$settings                               = $GLOBALS['plan_your_day_test_options'][ Settings::OPTION_NAME ];
+		$settings['google_geocoding_cache_ttl'] = 0;
+		update_option( Settings::OPTION_NAME, $settings );
+
+		$recording_client                 = new RecordingGoogleApiClient();
+		$recording_client->geocode_result = GoogleApiResult::failure(
+			'geocoding_zero_results',
+			'Google geocoding could not find this address.',
+			200,
+			false
+		);
+		$client                           = new CachedGoogleApiClient( $recording_client, new Settings(), new GoogleApiCache() );
+
+		$first  = $client->geocode( 'Unknown Test Address' );
+		$second = $client->geocode( 'Unknown Test Address' );
+
+		self::assertFalse( $first->is_success() );
+		self::assertFalse( $first->is_retryable() );
+		self::assertSame( $first->to_array(), $second->to_array() );
+		self::assertSame( 1, $recording_client->geocode_calls );
+		self::assertNotEmpty( $GLOBALS['plan_your_day_test_transients'] );
+	}
 }
 
 final class RecordingGoogleHttpTransport implements GoogleHttpTransportInterface {
 	public array $last_get_args = [];
+	public string $last_get_url = '';
 	public array $last_post_args = [];
 	public array $last_post_body = [];
+	public mixed $get_response = null;
+	public int $get_response_code = 200;
+	public string $get_response_body = '';
 	public string $post_response_body = '{}';
 
 	public function get( string $url, array $args = [] ) {
 		$this->last_get_args = $args;
+		$this->last_get_url  = $url;
+
+		if ( null !== $this->get_response ) {
+			return $this->get_response;
+		}
 
 		return [
 			'response' => [
-				'code' => 200,
+				'code' => $this->get_response_code,
 			],
-			'body'     => wp_json_encode(
+			'body'     => '' !== $this->get_response_body ? $this->get_response_body : wp_json_encode(
 				[
 					'id'               => 'place-1',
 					'displayName'      => [
@@ -241,8 +332,10 @@ final class RecordingGoogleHttpTransport implements GoogleHttpTransportInterface
 
 final class RecordingGoogleApiClient implements GoogleApiClientInterface {
 	public int $text_search_calls = 0;
+	public int $geocode_calls = 0;
 	public array $text_search_page_tokens = [];
 	public ?GoogleApiResult $text_search_result = null;
+	public ?GoogleApiResult $geocode_result = null;
 
 	public function text_search( string $query, ?float $origin_latitude = null, ?float $origin_longitude = null, string $page_token = '' ): GoogleApiResult {
 		++$this->text_search_calls;
@@ -268,6 +361,12 @@ final class RecordingGoogleApiClient implements GoogleApiClientInterface {
 	}
 
 	public function geocode( string $address ): GoogleApiResult {
+		++$this->geocode_calls;
+
+		if ( $this->geocode_result instanceof GoogleApiResult ) {
+			return $this->geocode_result;
+		}
+
 		return GoogleApiResult::success( [] );
 	}
 }


### PR DESCRIPTION
## Summary
- Classifies Google Geocoding body statuses for quota, denial, rate limiting, unknown errors, and zero-result responses.
- Marks transport `WP_Error` failures as retryable.
- Removes raw provider body/full response logging from Google response failures.
- Applies short cooldown caching to selected provider failures so denial/quota/zero-result responses do not repeatedly hit Google.

## Verification
- `composer test` in `plugin/plan-your-day` passed: 108 tests, 588 assertions.
- `git diff --check`